### PR TITLE
Optic setup

### DIFF
--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,0 +1,2 @@
+[global]
+port = 5347

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  title: Survey Service
+  version: "1.0"
+paths:
+  /:
+    get:
+      summary: hello world
+      responses:
+        "200":
+          description: "hello world"
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"build": "yarn workspaces run build",
 		"preview": "yarn workspace frontend preview",
 		"dev": "yarn workspace frontend dev",
+		"dev:capture": "optic oas capture docs/api.yml http://localhost:5347 --command \"yarn workspace frontend dev\"",
 		"check": "yarn workspaces run check",
 		"lint": "yarn workspaces run lint",
 		"test:unit": "yarn workspaces run test:unit",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"dev:capture": "optic oas capture docs/api.yml http://localhost:5347 --command \"yarn workspace frontend dev\"",
 		"check": "yarn workspaces run check",
 		"lint": "yarn workspaces run lint",
+		"lint:fix": "yarn workspaces run lint:fix",
 		"test:unit": "yarn workspaces run test:unit",
 		"test:e2e": "yarn workspace frontend test",
 		"format": "yarn workspaces run format"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,6 +14,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
+		"lint:fix": "prettier --plugin-search-dir . --write . && eslint . --fix",
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -3,6 +3,13 @@ import type { UserConfig } from 'vite';
 
 const config: UserConfig = {
 	plugins: [sveltekit()],
+	server: {
+		proxy: {
+			"^/api": {
+				target: "http://localhost:5347",
+			},
+		},
+	},
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -5,10 +5,10 @@ const config: UserConfig = {
 	plugins: [sveltekit()],
 	server: {
 		proxy: {
-			"^/api": {
-				target: "http://localhost:5347",
-			},
-		},
+			'^/api': {
+				target: 'http://localhost:5347'
+			}
+		}
 	},
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']

--- a/scripts/install-extras.sh
+++ b/scripts/install-extras.sh
@@ -6,4 +6,4 @@ set -e
 
 cargo install cargo-watch
 cargo install typeshare-cli
-yarn global add @useoptic/optic
+npm install -g @useoptic/optic

--- a/scripts/install-extras.sh
+++ b/scripts/install-extras.sh
@@ -6,3 +6,4 @@ set -e
 
 cargo install cargo-watch
 cargo install typeshare-cli
+yarn global add @useoptic/optic


### PR DESCRIPTION
- add optic to install script
- add minimal api spec
- fix optic install in setup script
- change default port for backend
- add dev:capture script for front end

This sets up some workspace infra so we can use [optic](https://useoptic.com) to automate API documentation. This doesn't add anything to the CI pipelines, but that can be done later.

There's also some misc additions to workspace infra.
