### PR TITLE
Add UI Primitives

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,6 +19,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",
+		"@rgossiaux/svelte-headlessui": "^1.0.2",
 		"@sveltejs/adapter-auto": "^1.0.0",
 		"@sveltejs/kit": "^1.0.0",
 		"@typescript-eslint/eslint-plugin": "^5.45.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,5 +35,8 @@
 		"vite": "^4.0.0",
 		"vitest": "^0.25.3"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"sass": "^1.58.0"
+	}
 }

--- a/packages/frontend/src/lib/questions/QTextInput.svelte
+++ b/packages/frontend/src/lib/questions/QTextInput.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import TextBox from '$lib/ui/TextBox.svelte';
+
 	export let editmode = false;
 	export let multiline = false;
 	let response = '';
@@ -9,7 +11,7 @@
 <div>
 	<div>
 		{#if editmode}
-			<input bind:value={prompt} />
+			<TextBox bind:value={prompt} />
 		{:else}
 			<span>{prompt}</span>
 		{/if}
@@ -17,15 +19,11 @@
 
 	<div>
 		{#if editmode}
-			<input bind:value={description} />
+			<TextBox bind:value={description} />
 		{:else}
 			<span>{description}</span>
 		{/if}
 	</div>
 
-	{#if multiline}
-		<textarea bind:value={response} disabled={editmode} />
-	{:else}
-		<input bind:value={response} disabled={editmode} />
-	{/if}
+	<TextBox bind:value={response} disabled={editmode} {multiline} />
 </div>

--- a/packages/frontend/src/lib/ui/Button.svelte
+++ b/packages/frontend/src/lib/ui/Button.svelte
@@ -10,8 +10,9 @@
 	 */
 	export let pressed = false;
 	export let size: 'small' | 'normal' | 'large' = 'normal';
+	export let kind: 'primary' | 'default' = 'default';
 
-	$: classes = `sz-${size}`;
+	$: classes = `sz-${size} kind-${kind}`;
 
 	const dispatch = createEventDispatcher();
 
@@ -61,5 +62,10 @@
 	.sz-large {
 		font-size: 1.4em;
 		padding: 0.6em 4em;
+	}
+
+	.kind-primary {
+		background-color: #000;
+		color: #fff;
 	}
 </style>

--- a/packages/frontend/src/lib/ui/Button.svelte
+++ b/packages/frontend/src/lib/ui/Button.svelte
@@ -44,6 +44,13 @@
 		background-color: #fff;
 	}
 
+	button:active {
+		background-color: #000;
+		color: #fff;
+		position: relative;
+		top: 1px;
+	}
+
 	[aria-pressed='true'] {
 		background-color: #000;
 		color: #fff;
@@ -67,5 +74,10 @@
 	.kind-primary {
 		background-color: #000;
 		color: #fff;
+	}
+
+	.kind-primary:active {
+		background-color: #fff;
+		color: #000;
 	}
 </style>

--- a/packages/frontend/src/lib/ui/Button.svelte
+++ b/packages/frontend/src/lib/ui/Button.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	/**
+	 * Makes the button toggle when clicked.
+	 */
+	export let toggleable = false;
+	/**
+	 * Whether the button is currently pressed.
+	 */
+	export let pressed = false;
+	export let size: 'small' | 'normal' | 'large' = 'normal';
+
+	$: classes = `sz-${size}`;
+
+	const dispatch = createEventDispatcher();
+
+	function toggle() {
+		pressed = !pressed;
+	}
+
+	function handleClick(e: Event) {
+		toggle();
+		dispatch('click', e);
+	}
+</script>
+
+{#if toggleable}
+	<button class={classes} aria-pressed={pressed} on:click={handleClick}>
+		<slot />
+	</button>
+{:else}
+	<button class={classes} on:click>
+		<slot />
+	</button>
+{/if}
+
+<style lang="scss">
+	button {
+		cursor: pointer;
+		border: #000 3px solid;
+		border-radius: 5px;
+		background-color: #fff;
+	}
+
+	[aria-pressed='true'] {
+		background-color: #000;
+		color: #fff;
+	}
+
+	.sz-small {
+		font-size: 0.8em;
+		padding: 0.2em 0.5em;
+	}
+
+	.sz-normal {
+		font-size: 1em;
+		padding: 0.5em 2em;
+	}
+
+	.sz-large {
+		font-size: 1.4em;
+		padding: 0.6em 4em;
+	}
+</style>

--- a/packages/frontend/src/lib/ui/TextBox.svelte
+++ b/packages/frontend/src/lib/ui/TextBox.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	export let multiline = false;
+	export let placeholder = '';
+	export let value = '';
+	export let disabled = false;
+</script>
+
+{#if multiline}
+	<textarea rows="4" cols="50" {placeholder} {disabled} bind:value />
+{:else}
+	<input type="text" {placeholder} {disabled} bind:value />
+{/if}
+
+<style lang="scss">
+	input,
+	textarea {
+		border: #000 3px solid;
+		border-radius: 5px;
+		background-color: #fff;
+	}
+</style>

--- a/packages/frontend/src/routes/+page.svelte
+++ b/packages/frontend/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import QContainer from '$lib/QContainer.svelte';
+	import Button from '$lib/ui/Button.svelte';
 	import QTextInput from '../lib/questions/QTextInput.svelte';
 
 	let editmode = false;
@@ -9,6 +10,22 @@
 <p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
 
 <h2>Component Demo</h2>
+
+<h3>UI Primitives</h3>
+
+<div>
+	<Button>Default</Button>
+</div>
+<div>
+	<Button size="small">Small</Button>
+	<Button size="normal">Normal</Button>
+	<Button size="large">Large</Button><br />
+</div>
+<div>
+	<Button toggleable={true}>Toggle Button</Button>
+</div>
+
+<h3>Questions</h3>
 
 <div>
 	<input type="checkbox" id="editmode" bind:checked={editmode} />

--- a/packages/frontend/src/routes/+page.svelte
+++ b/packages/frontend/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 Buttons
 <div>
 	<Button>Default</Button>
+	<Button kind="primary">Primary</Button>
 </div>
 <div>
 	<Button size="small">Small</Button>

--- a/packages/frontend/src/routes/+page.svelte
+++ b/packages/frontend/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import QContainer from '$lib/QContainer.svelte';
 	import Button from '$lib/ui/Button.svelte';
+	import TextBox from '$lib/ui/TextBox.svelte';
 	import QTextInput from '../lib/questions/QTextInput.svelte';
 
 	let editmode = false;
@@ -13,6 +14,7 @@
 
 <h3>UI Primitives</h3>
 
+Buttons
 <div>
 	<Button>Default</Button>
 </div>
@@ -23,6 +25,14 @@
 </div>
 <div>
 	<Button toggleable={true}>Toggle Button</Button>
+</div>
+
+Textboxes
+<div>
+	<TextBox placeholder="placeholder" />
+</div>
+<div>
+	<TextBox placeholder="placeholder" multiline={true} />
 </div>
 
 <h3>Questions</h3>

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,11 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
+"@rgossiaux/svelte-headlessui@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@rgossiaux/svelte-headlessui/-/svelte-headlessui-1.0.2.tgz#9493251a40cd56d8bdc8f0f64623d886bb872b1e"
+  integrity sha512-sauopYTSivhzXe1kAvgawkhyYJcQlK8Li3p0d2OtcCIVprOzdbard5lbqWB4xHDv83zAobt2mR08oizO2poHLQ==
+
 "@sveltejs/adapter-auto@^1.0.0":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@sveltejs/adapter-auto/-/adapter-auto-1.0.2.tgz#c44591b1b1ef75e66c158067bab9d2789836fa54"

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,7 +491,7 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
-chokidar@^3.4.1:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -924,6 +924,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immutable@^4.0.0:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.2.4.tgz#83260d50889526b4b531a5e293709a77f7c55a2a"
+  integrity sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -1341,6 +1346,15 @@ sander@^0.5.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
+sass@^1.58.0:
+  version "1.58.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.58.0.tgz#ee8aea3ad5ea5c485c26b3096e2df6087d0bb1cc"
+  integrity sha512-PiMJcP33DdKtZ/1jSjjqVIKihoDc6yWmYr9K/4r3fVVIEDAluD0q7XZiRKrNJcPK3qkLRF/79DND1H5q1LBjgg==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 semver@^7.3.7:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
@@ -1389,7 +1403,7 @@ sorcery@^0.11.0:
     minimist "^1.2.0"
     sander "^0.5.0"
 
-source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==


### PR DESCRIPTION
- add sass as dependency
- add Button
- add headless ui as dependency
- add text box component
- change QTextInput to use TextBox component
- add `kind` prop to `Button`
- add visual effect when button is clicked

This adds the UI primitives specified in #19. These are by no means complete, but they are enough to be functional and easy to change later.

We will eventually need to actually have a visual style.

closes #19
