### PR TITLE
Add very basic survey response page

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -48,8 +48,9 @@ paths:
       - $ref: "#/components/parameters/survey"
     get:
       summary: Get a survey.
-      description: |
-        Get a survey. If the survey is not published, only the owner can get it. If the survey is published, anyone can get it.
+      description: >
+        Get a survey. If the survey is not published, only the owner can
+        get it. If the survey is published, anyone can get it.
       responses:
         "200":
           description: 200 response
@@ -116,13 +117,27 @@ paths:
                   - questions
     patch:
       summary: Update a survey
-      description: |
-        Update a survey. Only the owner of the survey can update it. If the survey is published, it cannot be updated unless it is unpublished first.
+      description: >
+        Update a survey. Only the owner of the survey can update it. If the
+        survey is published, it cannot be updated unless it is unpublished
+        first.
+
 
         The request body can contain any of the top level fields, but they are not required. If a field is not present, it will not be updated.
       responses:
         "200":
           description: The survey was updated
+        "403":
+          description: 403 response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
       requestBody:
         content:
           application/json:

--- a/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
+++ b/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { Survey } from '$lib/common';
+	import QContainer from '$lib/QContainer.svelte';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	let survey: Survey = data.survey;
+</script>
+
+<h1>{survey.title}</h1>
+<p>{survey.description}</p>
+
+{#each survey.questions as surveyquestion}
+	<QContainer question={surveyquestion.question} />
+{/each}

--- a/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
+++ b/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
@@ -3,6 +3,7 @@
 	import QContainer from '$lib/QContainer.svelte';
 	import Button from '$lib/ui/Button.svelte';
 	import type { PageData } from './$types';
+	import { goto } from '$app/navigation';
 
 	export let data: PageData;
 
@@ -16,4 +17,12 @@
 	<QContainer question={surveyquestion.question} />
 {/each}
 
-<Button size="large" kind="primary">Submit</Button>
+<!-- TODO: actually submit survey to get the response UUID -->
+<Button
+	size="large"
+	kind="primary"
+	on:click={() =>
+		goto(`/survey/${data.slug}/submitted?response=1d3fd956-2c6b-4439-9c8f-c6933f6d895c`)}
+>
+	Submit
+</Button>

--- a/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
+++ b/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Survey } from '$lib/common';
 	import QContainer from '$lib/QContainer.svelte';
+	import Button from '$lib/ui/Button.svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -14,3 +15,5 @@
 {#each survey.questions as surveyquestion}
 	<QContainer question={surveyquestion.question} />
 {/each}
+
+<Button size="large" kind="primary">Submit</Button>

--- a/packages/frontend/src/routes/survey/[slug]/respond/+page.ts
+++ b/packages/frontend/src/routes/survey/[slug]/respond/+page.ts
@@ -1,0 +1,15 @@
+import type { PageLoad } from './$types';
+import type { Survey } from '$lib/common';
+
+export const load = (async ({ params }) => {
+	// TODO: don't hardcode api host
+	// TODO: handle errors returned by the API
+	const survey: Survey = await fetch(`http://localhost:5173/api/survey/${params.slug}`).then((r) =>
+		r.json()
+	);
+
+	return {
+		slug: params.slug,
+		survey
+	};
+}) satisfies PageLoad;

--- a/packages/frontend/src/routes/survey/[slug]/submitted/+page.svelte
+++ b/packages/frontend/src/routes/survey/[slug]/submitted/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import TextBox from '$lib/ui/TextBox.svelte';
+
+	export let data: PageData;
+
+	let responseUuid = new URLSearchParams(window.location.search).get('response');
+
+	$: responseUrl = `${window.location.origin}/survey/${data.slug}/respond?response=${responseUuid}`;
+</script>
+
+<h1>Response Submitted</h1>
+
+<div>
+	<span>Save this link to edit your response later:</span>
+</div>
+
+<div>
+	<TextBox value={responseUrl} />
+</div>
+
+<div>
+	<a href={responseUrl}>Or click here to edit it right away.</a>
+</div>

--- a/packages/frontend/src/routes/survey/[slug]/submitted/+page.ts
+++ b/packages/frontend/src/routes/survey/[slug]/submitted/+page.ts
@@ -1,8 +1,7 @@
 import type { PageLoad } from './$types';
 
-
 export const load = (async ({ params }) => {
 	return {
-		slug: params.slug,
+		slug: params.slug
 	};
 }) satisfies PageLoad;

--- a/packages/frontend/src/routes/survey/[slug]/submitted/+page.ts
+++ b/packages/frontend/src/routes/survey/[slug]/submitted/+page.ts
@@ -1,0 +1,8 @@
+import type { PageLoad } from './$types';
+
+
+export const load = (async ({ params }) => {
+	return {
+		slug: params.slug,
+	};
+}) satisfies PageLoad;


### PR DESCRIPTION
Adds survey response page at `/survey/<survey_id>/respond`

### Test plan

_requires bug fixes in #39 to work properly_

1. Create a survey: `POST /api/survey/create`
2. Edit the survey: `PATCH /api/survey/<survey_id>`

Use this body:
```json
{
	"title": "Test Survey",
	"description": "This is a test survey",
	"published": true,
	"questions": [
		{
			"uuid": "0826e038-382d-431b-b8fa-80599bd628e3",
			"required": true,
			"question": {
				"type": "Text",
				"content": {
					"prompt": "What is your name?",
					"description": "First and last name please.",
					"multiline": false
				}
			}
		},
		{
			"uuid": "0cd8d4c1-b254-4688-a8a4-f4363bafba56",
			"required": true,
			"question": {
				"type": "Text",
				"content": {
					"prompt": "In as much detail as possible, what are the consequences of the industrial revolution?",
					"description": "Wrong answers only.",
					"multiline": true
				}
			}
		}
	]
}
```

3. In browser, navigate to `/survey/<survey_id>/respond`
4. See survey with 2 text questions and submit button.
5. Click submit
6. See "response submitted" page


closes #14


