### PR TITLE
List surveys endpoint and more unit tests

### DIFF
--- a/crates/api_server/src/db/models.rs
+++ b/crates/api_server/src/db/models.rs
@@ -63,6 +63,18 @@ impl NewSurvey {
     }
 }
 
+/// Used to list surveys, like on the page where you can see all your surveys
+#[typeshare]
+#[derive(Queryable, Serialize, Deserialize)]
+#[diesel(table_name=surveys)]
+pub struct ListedSurvey {
+    pub id: i32,
+    pub title: String,
+    pub description: String,
+    pub published: bool,
+    pub owner_id: i32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, AsExpression, FromSqlRow)]
 #[diesel(sql_type = Jsonb)]
 #[typeshare(serialized_as = "Vec<SurveyQuestion>")]

--- a/crates/api_server/src/main.rs
+++ b/crates/api_server/src/main.rs
@@ -11,6 +11,8 @@ pub mod jwt;
 mod questions;
 mod survey;
 mod user;
+#[cfg(test)]
+mod test_helpers;
 
 #[get("/")]
 fn index() -> &'static str {
@@ -25,6 +27,7 @@ pub fn rocket() -> _ {
             index,
             user::register_user,
             user::login_user,
+            user::list_surveys,
             survey::create_survey,
             survey::get_survey,
             survey::get_survey_auth,

--- a/crates/api_server/src/main.rs
+++ b/crates/api_server/src/main.rs
@@ -10,9 +10,9 @@ mod db;
 pub mod jwt;
 mod questions;
 mod survey;
-mod user;
 #[cfg(test)]
 mod test_helpers;
+mod user;
 
 #[get("/")]
 fn index() -> &'static str {

--- a/crates/api_server/src/survey.rs
+++ b/crates/api_server/src/survey.rs
@@ -163,102 +163,11 @@ async fn get_survey_from_db(db: &Storage, survey_id: i32) -> anyhow::Result<Surv
 
 #[cfg(test)]
 mod tests {
-    use std::panic;
-
     use crate::db::models::SurveyQuestions;
 
     use super::*;
-    use diesel::{sql_query, Connection, PgConnection, RunQueryDsl};
-    use jsonwebtoken::EncodingKey;
+    use crate::test_helpers::*;
     use rocket::local::blocking::Client;
-
-    fn create_db_for_tests() -> String {
-        let db_name = format!("survey_app_test_{}", uuid::Uuid::new_v4()).replace("-", "_");
-        let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
-            .expect("Failed to connect to database");
-        sql_query(format!("CREATE DATABASE {db_name}"))
-            .execute(&mut conn)
-            .expect("Failed to create test database");
-        db_name.to_string()
-    }
-
-    fn drop_test_db(db_name: String) {
-        let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
-            .expect("Failed to connect to database");
-        sql_query(format!("DROP DATABASE IF EXISTS {db_name}"))
-            .execute(&mut conn)
-            .expect("Failed to drop test database");
-    }
-
-    fn create_test_user(client: &Client) -> String {
-        let response = client
-            .post(uri!("/api", crate::user::register_user))
-            .header(rocket::http::ContentType::JSON)
-            .body(r#"{"username": "test", "password": "test"}"#)
-            .dispatch();
-        format!(
-            "Bearer {}",
-            response
-                .into_json::<crate::user::UserToken>()
-                .unwrap()
-                .token
-        )
-    }
-
-    fn make_jwt(client: &Client, user_id: i32) -> String {
-        let key =
-            EncodingKey::from_secret(client.rocket().config().secret_key.to_string().as_bytes());
-        let claims = Claims::new(user_id);
-        let token = jsonwebtoken::encode(&jsonwebtoken::Header::default(), &claims, &key).unwrap();
-        "Bearer ".to_string() + &token
-    }
-
-    fn run_test_with_db<T>(test: T) -> ()
-    where
-        T: FnOnce(&String) -> () + panic::UnwindSafe,
-    {
-        let db_name = create_db_for_tests();
-        let result = panic::catch_unwind(|| test(&db_name));
-        drop_test_db(db_name);
-        assert!(result.is_ok())
-    }
-
-    fn test_rocket(db_name: &String) -> rocket::Rocket<rocket::Build> {
-        let rocket = crate::rocket();
-        let config = rocket
-            .figment()
-            .clone()
-            .merge((
-                "databases.survey_app_test.url",
-                format!("postgres://vscode:notsecure@db/{}", db_name),
-            ))
-            .merge(("databases.survey_app_test.pool_size", 1));
-        return rocket.configure(config);
-    }
-
-    fn create_survey(client: &Client, token: &String) -> i32 {
-        let response = client
-            .post(uri!("/api", create_survey))
-            .header(rocket::http::ContentType::JSON)
-            .header(rocket::http::Header::new("Authorization", token.clone()))
-            .dispatch();
-        response.into_json::<Survey>().unwrap().id
-    }
-
-    fn publish_survey(client: &Client, token: &String, survey_id: i32) {
-        client
-            .patch(uri!("/api", edit_survey(survey_id)).to_string())
-            .header(rocket::http::ContentType::JSON)
-            .header(rocket::http::Header::new("Authorization", token.clone()))
-            .body(
-                serde_json::to_vec(&SurveyPatch {
-                    published: Some(true),
-                    ..Default::default()
-                })
-                .unwrap(),
-            )
-            .dispatch();
-    }
 
     #[test]
     fn test_create_survey() {
@@ -282,7 +191,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
 
             let response = client
                 .get(uri!("/api", get_survey(survey_id)).to_string())
@@ -300,7 +209,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
             publish_survey(&client, &token, survey_id);
 
             let response = client
@@ -318,7 +227,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
             let token = make_jwt(&client, 58008);
 
             let response = client
@@ -337,7 +246,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
 
             let response = client
                 .get(uri!("/api", get_survey(survey_id)).to_string())
@@ -354,7 +263,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
             publish_survey(&client, &token, survey_id);
 
             let token = make_jwt(&client, 58008);
@@ -375,7 +284,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
 
             let response = client
                 .patch(uri!("/api", edit_survey(survey_id)).to_string())
@@ -415,7 +324,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
             publish_survey(&client, &token, survey_id);
 
             let response = client
@@ -441,7 +350,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
             publish_survey(&client, &token, survey_id);
 
             let response = client
@@ -467,7 +376,7 @@ mod tests {
             let client = Client::tracked(test_rocket(db_name)).expect("valid rocket instance");
 
             let token = create_test_user(&client);
-            let survey_id = create_survey(&client, &token);
+            let survey_id = make_survey(&client, &token);
             publish_survey(&client, &token, survey_id);
 
             let token = make_jwt(&client, 58008);

--- a/crates/api_server/src/test_helpers.rs
+++ b/crates/api_server/src/test_helpers.rs
@@ -1,0 +1,93 @@
+use diesel::{sql_query, Connection, PgConnection, RunQueryDsl};
+use jsonwebtoken::EncodingKey;
+use rocket::local::blocking::Client;
+
+use crate::{jwt::Claims, db::models::{Survey, SurveyPatch}};
+
+pub fn create_db_for_tests() -> String {
+	let db_name = format!("survey_app_test_{}", uuid::Uuid::new_v4()).replace("-", "_");
+	let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
+		.expect("Failed to connect to database");
+	sql_query(format!("CREATE DATABASE {db_name}"))
+		.execute(&mut conn)
+		.expect("Failed to create test database");
+	db_name.to_string()
+}
+
+pub fn drop_test_db(db_name: String) {
+	let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
+		.expect("Failed to connect to database");
+	sql_query(format!("DROP DATABASE IF EXISTS {db_name}"))
+		.execute(&mut conn)
+		.expect("Failed to drop test database");
+}
+
+pub fn create_test_user(client: &Client) -> String {
+	let response = client
+		.post(uri!("/api", crate::user::register_user))
+		.header(rocket::http::ContentType::JSON)
+		.body(r#"{"username": "test", "password": "test"}"#)
+		.dispatch();
+	format!(
+		"Bearer {}",
+		response
+			.into_json::<crate::user::UserToken>()
+			.unwrap()
+			.token
+	)
+}
+
+pub fn make_jwt(client: &Client, user_id: i32) -> String {
+	let key =
+		EncodingKey::from_secret(client.rocket().config().secret_key.to_string().as_bytes());
+	let claims = Claims::new(user_id);
+	let token = jsonwebtoken::encode(&jsonwebtoken::Header::default(), &claims, &key).unwrap();
+	"Bearer ".to_string() + &token
+}
+
+pub fn run_test_with_db<T>(test: T) -> ()
+where
+	T: FnOnce(&String) -> () + std::panic::UnwindSafe,
+{
+	let db_name = create_db_for_tests();
+	let result = std::panic::catch_unwind(|| test(&db_name));
+	drop_test_db(db_name);
+	assert!(result.is_ok())
+}
+
+pub fn test_rocket(db_name: &String) -> rocket::Rocket<rocket::Build> {
+	let rocket = crate::rocket();
+	let config = rocket
+		.figment()
+		.clone()
+		.merge((
+			"databases.survey_app_test.url",
+			format!("postgres://vscode:notsecure@db/{}", db_name),
+		))
+		.merge(("databases.survey_app_test.pool_size", 1));
+	return rocket.configure(config);
+}
+
+pub fn make_survey(client: &Client, token: &String) -> i32 {
+	let response = client
+		.post(uri!("/api", crate::survey::create_survey))
+		.header(rocket::http::ContentType::JSON)
+		.header(rocket::http::Header::new("Authorization", token.clone()))
+		.dispatch();
+	response.into_json::<Survey>().unwrap().id
+}
+
+pub fn publish_survey(client: &Client, token: &String, survey_id: i32) {
+	client
+		.patch(uri!("/api", crate::survey::edit_survey(survey_id)).to_string())
+		.header(rocket::http::ContentType::JSON)
+		.header(rocket::http::Header::new("Authorization", token.clone()))
+		.body(
+			serde_json::to_vec(&SurveyPatch {
+				published: Some(true),
+				..Default::default()
+			})
+			.unwrap(),
+		)
+		.dispatch();
+}

--- a/crates/api_server/src/test_helpers.rs
+++ b/crates/api_server/src/test_helpers.rs
@@ -2,92 +2,97 @@ use diesel::{sql_query, Connection, PgConnection, RunQueryDsl};
 use jsonwebtoken::EncodingKey;
 use rocket::local::blocking::Client;
 
-use crate::{jwt::Claims, db::models::{Survey, SurveyPatch}};
+use crate::{
+    db::models::{Survey, SurveyPatch},
+    jwt::Claims,
+};
 
 pub fn create_db_for_tests() -> String {
-	let db_name = format!("survey_app_test_{}", uuid::Uuid::new_v4()).replace("-", "_");
-	let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
-		.expect("Failed to connect to database");
-	sql_query(format!("CREATE DATABASE {db_name}"))
-		.execute(&mut conn)
-		.expect("Failed to create test database");
-	db_name.to_string()
+    let db_name = format!("survey_app_test_{}", uuid::Uuid::new_v4()).replace("-", "_");
+    let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
+        .expect("Failed to connect to database");
+    sql_query(format!("CREATE DATABASE {db_name}"))
+        .execute(&mut conn)
+        .expect("Failed to create test database");
+    db_name.to_string()
 }
 
 pub fn drop_test_db(db_name: String) {
-	let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
-		.expect("Failed to connect to database");
-	sql_query(format!("DROP DATABASE IF EXISTS {db_name}"))
-		.execute(&mut conn)
-		.expect("Failed to drop test database");
+    let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
+        .expect("Failed to connect to database");
+    sql_query(format!("DROP DATABASE IF EXISTS {db_name}"))
+        .execute(&mut conn)
+        .expect("Failed to drop test database");
 }
 
 pub fn create_test_user(client: &Client) -> String {
-	let response = client
-		.post(uri!("/api", crate::user::register_user))
-		.header(rocket::http::ContentType::JSON)
-		.body(r#"{"username": "test", "password": "test"}"#)
-		.dispatch();
-	format!(
-		"Bearer {}",
-		response
-			.into_json::<crate::user::UserToken>()
-			.unwrap()
-			.token
-	)
+    let username = format!("test_user_{}", uuid::Uuid::new_v4());
+    let response = client
+        .post(uri!("/api", crate::user::register_user))
+        .header(rocket::http::ContentType::JSON)
+        .body(format!(
+            r#"{{"username": "{username}", "password": "test"}}"#
+        ))
+        .dispatch();
+    format!(
+        "Bearer {}",
+        response
+            .into_json::<crate::user::UserToken>()
+            .unwrap()
+            .token
+    )
 }
 
 pub fn make_jwt(client: &Client, user_id: i32) -> String {
-	let key =
-		EncodingKey::from_secret(client.rocket().config().secret_key.to_string().as_bytes());
-	let claims = Claims::new(user_id);
-	let token = jsonwebtoken::encode(&jsonwebtoken::Header::default(), &claims, &key).unwrap();
-	"Bearer ".to_string() + &token
+    let key = EncodingKey::from_secret(client.rocket().config().secret_key.to_string().as_bytes());
+    let claims = Claims::new(user_id);
+    let token = jsonwebtoken::encode(&jsonwebtoken::Header::default(), &claims, &key).unwrap();
+    "Bearer ".to_string() + &token
 }
 
 pub fn run_test_with_db<T>(test: T) -> ()
 where
-	T: FnOnce(&String) -> () + std::panic::UnwindSafe,
+    T: FnOnce(&String) -> () + std::panic::UnwindSafe,
 {
-	let db_name = create_db_for_tests();
-	let result = std::panic::catch_unwind(|| test(&db_name));
-	drop_test_db(db_name);
-	assert!(result.is_ok())
+    let db_name = create_db_for_tests();
+    let result = std::panic::catch_unwind(|| test(&db_name));
+    drop_test_db(db_name);
+    assert!(result.is_ok())
 }
 
 pub fn test_rocket(db_name: &String) -> rocket::Rocket<rocket::Build> {
-	let rocket = crate::rocket();
-	let config = rocket
-		.figment()
-		.clone()
-		.merge((
-			"databases.survey_app_test.url",
-			format!("postgres://vscode:notsecure@db/{}", db_name),
-		))
-		.merge(("databases.survey_app_test.pool_size", 1));
-	return rocket.configure(config);
+    let rocket = crate::rocket();
+    let config = rocket
+        .figment()
+        .clone()
+        .merge((
+            "databases.survey_app_test.url",
+            format!("postgres://vscode:notsecure@db/{}", db_name),
+        ))
+        .merge(("databases.survey_app_test.pool_size", 1));
+    return rocket.configure(config);
 }
 
 pub fn make_survey(client: &Client, token: &String) -> i32 {
-	let response = client
-		.post(uri!("/api", crate::survey::create_survey))
-		.header(rocket::http::ContentType::JSON)
-		.header(rocket::http::Header::new("Authorization", token.clone()))
-		.dispatch();
-	response.into_json::<Survey>().unwrap().id
+    let response = client
+        .post(uri!("/api", crate::survey::create_survey))
+        .header(rocket::http::ContentType::JSON)
+        .header(rocket::http::Header::new("Authorization", token.clone()))
+        .dispatch();
+    response.into_json::<Survey>().unwrap().id
 }
 
 pub fn publish_survey(client: &Client, token: &String, survey_id: i32) {
-	client
-		.patch(uri!("/api", crate::survey::edit_survey(survey_id)).to_string())
-		.header(rocket::http::ContentType::JSON)
-		.header(rocket::http::Header::new("Authorization", token.clone()))
-		.body(
-			serde_json::to_vec(&SurveyPatch {
-				published: Some(true),
-				..Default::default()
-			})
-			.unwrap(),
-		)
-		.dispatch();
+    client
+        .patch(uri!("/api", crate::survey::edit_survey(survey_id)).to_string())
+        .header(rocket::http::ContentType::JSON)
+        .header(rocket::http::Header::new("Authorization", token.clone()))
+        .body(
+            serde_json::to_vec(&SurveyPatch {
+                published: Some(true),
+                ..Default::default()
+            })
+            .unwrap(),
+        )
+        .dispatch();
 }

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -154,6 +154,18 @@ paths:
                   type: array
                   items:
                     $ref: "#/components/schemas/SurveyQuestion"
+  /api/user/surveys:
+    summary: Get all surveys owned by the user
+    get:
+      responses:
+        "200":
+          description: List of surveys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ListedSurvey"
 components:
   parameters:
     survey:
@@ -174,6 +186,25 @@ components:
       required:
         - username
         - password
+    ListedSurvey:
+      type: object
+      properties:
+        id:
+          type: number
+        title:
+          type: string
+        description:
+          type: string
+        published:
+          type: boolean
+        owner_id:
+          type: number
+      required:
+        - id
+        - title
+        - description
+        - published
+        - owner_id
     SurveyQuestion:
       type: object
       properties:

--- a/packages/frontend/src/lib/common.ts
+++ b/packages/frontend/src/lib/common.ts
@@ -21,6 +21,15 @@ export interface SurveyPatch {
 	questions?: SurveyQuestions;
 }
 
+/** Used to list surveys, like on the page where you can see all your surveys */
+export interface ListedSurvey {
+	id: number;
+	title: string;
+	description: string;
+	published: boolean;
+	owner_id: number;
+}
+
 export interface SurveyQuestion {
 	uuid: string;
 	required: boolean;


### PR DESCRIPTION
- move all unit testing helpers to test_helpers module
- add survey list endpoint
- document survey list endpoint
- add some more unit tests for user login endpoints

closes #31

### Test Plan

1. start api server: `cargo run`
2. register user: `POST /api/user/register`
```json
{"username": "a", "password":"a"}
```
3. create some surveys: `POST /api/survey/create`
4. list surveys: `GET /api/user/surveys`

Response should look like:
```json
[
	{
		"id": 2,
		"title": "",
		"description": "",
		"published": false,
		"owner_id": 4
	},
	{
		"id": 3,
		"title": "",
		"description": "",
		"published": false,
		"owner_id": 4
	},
	{
		"id": 4,
		"title": "",
		"description": "",
		"published": false,
		"owner_id": 4
	},
	...
]
```
