### PR TITLE
Benchmark setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +53,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +97,7 @@ dependencies = [
  "diesel_migrations",
  "jsonwebtoken",
  "password-hash",
+ "pprof",
  "rocket",
  "rocket_sync_db_pools",
  "serde",
@@ -96,6 +124,12 @@ dependencies = [
  "blake2",
  "password-hash",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-stream"
@@ -156,6 +190,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +257,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "bytemuck"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
 
 [[package]]
 name = "byteorder"
@@ -344,6 +399,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -498,6 +562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "devise"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +670,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +711,18 @@ dependencies = [
  "toml",
  "uncased",
  "version_check",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -735,6 +841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +900,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hkdf"
@@ -901,6 +1019,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1058,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -984,6 +1142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af2c65375e552a67fe3829ca63e8a7c27a378a62824594f43b2851d682b5ec2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,7 +1259,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1101,6 +1283,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1312,16 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -1148,6 +1351,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1200,7 +1412,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1305,6 +1517,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pprof"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20150f965e0e4c925982b9356da71c84bcd56cb66ef4e894825837cbcf6613e"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1597,15 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1500,6 +1743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7495acf66551cdb696b7711408144bcd3194fc78e32f3a09e809bfe7dd4a7ce3"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1866,26 @@ source = "git+https://github.com/SergioBenitez/Rocket#59ee2e033986f4bdfd465dcf8d
 dependencies = [
  "devise",
  "quote",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1783,6 +2055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "state"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,10 +2070,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "symbolic-common"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -1930,7 +2237,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2307,6 +2614,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.42.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +65,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "chrono",
+ "criterion",
  "diesel",
  "diesel_migrations",
  "jsonwebtoken",
@@ -70,6 +77,13 @@ dependencies = [
  "thiserror",
  "typeshare",
  "uuid",
+]
+
+[[package]]
+name = "api_server_bin"
+version = "0.1.0"
+dependencies = [
+ "api_server",
 ]
 
 [[package]]
@@ -208,6 +222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +255,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +289,27 @@ checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -284,6 +352,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -613,6 +760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1031,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "migrations_internals"
@@ -986,10 +1157,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -1080,6 +1263,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polyval"
@@ -1202,6 +1413,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1394,6 +1627,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -1590,6 +1832,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1902,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1902,6 +2160,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -3,6 +3,3 @@ port = 5347
 
 [default.databases.survey_app]
 url = "postgres://vscode:notsecure@db/survey_app"
-
-[default.databases.survey_app_test]
-url = "postgres://vscode:notsecure@db/survey_app_test"

--- a/crates/api_server/Cargo.toml
+++ b/crates/api_server/Cargo.toml
@@ -23,3 +23,10 @@ uuid = { version = "1.3.0", features = ["serde", "v4"] }
 [dependencies.rocket_sync_db_pools]
 git = "https://github.com/SergioBenitez/Rocket"
 features = ["diesel_postgres_pool"]
+
+[dev-dependencies]
+criterion = "0.4"
+
+[[bench]]
+name = "surveys"
+harness = false

--- a/crates/api_server/Cargo.toml
+++ b/crates/api_server/Cargo.toml
@@ -26,7 +26,11 @@ features = ["diesel_postgres_pool"]
 
 [dev-dependencies]
 criterion = "0.4"
+pprof = { version = "0.11", features = ["flamegraph", "criterion"] }
 
 [[bench]]
 name = "surveys"
 harness = false
+
+[profile.bench]
+debug = true

--- a/crates/api_server/benches/surveys.rs
+++ b/crates/api_server/benches/surveys.rs
@@ -80,5 +80,78 @@ fn get_survey(c: &mut Criterion) {
     drop_test_db(db_name);
 }
 
-criterion_group!(benches, get_survey);
+fn patch_survey(c: &mut Criterion) {
+    let questions = vec![
+        QText {
+            prompt: "What is your name?".to_string(),
+            description: "Please enter your name".to_string(),
+            multiline: false,
+        }.into(),
+        QRating {
+            prompt: "Rate the foobar".to_string(),
+            description: "1 is the worst, 5 is the best".to_string(),
+            max_rating: 5
+        }.into(),
+        QMultipleChoice {
+            prompt: "Pick one".to_string(),
+            description: "yes".to_string(),
+        }.into(),
+        QText {
+            prompt: "What is your name?".to_string(),
+            description: "Please enter your name".to_string(),
+            multiline: true,
+        }.into(),
+        QRating {
+            prompt: "Rate the foobar".to_string(),
+            description: "1 is the worst, 5 is the best".to_string(),
+            max_rating: 5
+        }.into(),
+    ].into_iter().map(|q| {
+        SurveyQuestion {
+            uuid: uuid::Uuid::new_v4(),
+            required: false,
+            question: q,
+        }
+    }).collect::<Vec<_>>();
+
+    let db_name = create_db_for_tests();
+    let client = Client::untracked(bench_rocket(&db_name)).expect("valid rocket instance");
+    let token = create_test_user(&client);
+    fn make_test_survey(client: &Client, token: &String, questions: &Vec<SurveyQuestion>, mut amount: usize) -> (i32, Vec<u8>) {
+        let survey_id = make_survey(&client, &token);
+        let mut q = vec![];
+        while amount > questions.len() {
+            q.extend(questions.clone());
+            amount -= questions.len();
+        }
+        q.extend(questions[..amount].to_vec());
+
+        let body = serde_json::to_vec(&SurveyPatch {
+            title: Some("Benchmark Survey".to_string()),
+            published: Some(true),
+            questions: Some(q.into()),
+            ..Default::default()
+        })
+        .unwrap();
+        (survey_id, body)
+    }
+
+    for survey_size in [2, 4, 8, 16, 32].iter() {
+        let (survey_id, body) = make_test_survey(&client, &token, &questions, *survey_size);
+
+        c.bench_function(&format!("patch survey: {} questions", survey_size), |b| b.iter(|| {
+            let resp = client.get(uri!("/api", api_server::survey::edit_survey(survey_id))
+            .to_string())
+            .header(rocket::http::ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", token.clone()))
+            .body(body.clone())
+                .dispatch();
+            black_box(resp);
+        }));
+    }
+
+    drop_test_db(db_name);
+}
+
+criterion_group!(benches, get_survey, patch_survey);
 criterion_main!(benches);

--- a/crates/api_server/benches/surveys.rs
+++ b/crates/api_server/benches/surveys.rs
@@ -4,6 +4,7 @@ use api_server::test_helpers::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rocket::local::blocking::Client;
 use rocket::uri;
+use pprof::criterion::{PProfProfiler, Output};
 
 fn get_survey(c: &mut Criterion) {
     let questions = vec![
@@ -179,5 +180,9 @@ fn patch_survey(c: &mut Criterion) {
     drop_test_db(db_name);
 }
 
-criterion_group!(benches, get_survey, patch_survey);
+criterion_group!{
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = get_survey, patch_survey
+}
 criterion_main!(benches);

--- a/crates/api_server/benches/surveys.rs
+++ b/crates/api_server/benches/surveys.rs
@@ -41,7 +41,7 @@ fn get_survey(c: &mut Criterion) {
     }).collect::<Vec<_>>();
 
     let db_name = create_db_for_tests();
-    let client = Client::untracked(test_rocket(&db_name)).expect("valid rocket instance");
+    let client = Client::untracked(bench_rocket(&db_name)).expect("valid rocket instance");
     let token = create_test_user(&client);
     fn make_test_survey(client: &Client, token: &String, questions: &Vec<SurveyQuestion>, mut amount: usize) -> i32 {
         let survey_id = make_survey(&client, &token);

--- a/crates/api_server/benches/surveys.rs
+++ b/crates/api_server/benches/surveys.rs
@@ -1,7 +1,7 @@
 use api_server::db::models::SurveyPatch;
 use api_server::questions::{QMultipleChoice, QRating, QText, SurveyQuestion};
 use api_server::test_helpers::*;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
 use rocket::local::blocking::Client;
 use rocket::uri;
 use pprof::criterion::{PProfProfiler, Output};
@@ -81,7 +81,7 @@ fn get_survey(c: &mut Criterion) {
 
     for survey_size in [2, 4, 8, 16, 32].iter() {
         let survey_id = make_test_survey(&client, &token, &questions, *survey_size);
-        c.bench_function(&format!("get survey: {} questions", survey_size), |b| {
+        c.bench_with_input(BenchmarkId::new("get_survey", survey_size), survey_size, |b, _| {
             b.iter(|| {
                 let resp = client
                     .get(uri!("/api", api_server::survey::get_survey(survey_id)).to_string())
@@ -164,7 +164,7 @@ fn patch_survey(c: &mut Criterion) {
     for survey_size in [2, 4, 8, 16, 32].iter() {
         let (survey_id, body) = make_test_survey(&client, &token, &questions, *survey_size);
 
-        c.bench_function(&format!("patch survey: {} questions", survey_size), |b| {
+        c.bench_with_input(BenchmarkId::new("patch_survey", survey_size), survey_size, |b, _| {
             b.iter(|| {
                 let resp = client
                     .get(uri!("/api", api_server::survey::edit_survey(survey_id)).to_string())

--- a/crates/api_server/benches/surveys.rs
+++ b/crates/api_server/benches/surveys.rs
@@ -1,10 +1,9 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use api_server::questions::{SurveyQuestion, QText, QRating, QMultipleChoice};
-use api_server::test_helpers::*;
 use api_server::db::models::SurveyPatch;
+use api_server::questions::{QMultipleChoice, QRating, QText, SurveyQuestion};
+use api_server::test_helpers::*;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rocket::local::blocking::Client;
 use rocket::uri;
-
 
 fn get_survey(c: &mut Criterion) {
     let questions = vec![
@@ -12,38 +11,49 @@ fn get_survey(c: &mut Criterion) {
             prompt: "What is your name?".to_string(),
             description: "Please enter your name".to_string(),
             multiline: false,
-        }.into(),
+        }
+        .into(),
         QRating {
             prompt: "Rate the foobar".to_string(),
             description: "1 is the worst, 5 is the best".to_string(),
-            max_rating: 5
-        }.into(),
+            max_rating: 5,
+        }
+        .into(),
         QMultipleChoice {
             prompt: "Pick one".to_string(),
             description: "yes".to_string(),
-        }.into(),
+        }
+        .into(),
         QText {
             prompt: "What is your name?".to_string(),
             description: "Please enter your name".to_string(),
             multiline: true,
-        }.into(),
+        }
+        .into(),
         QRating {
             prompt: "Rate the foobar".to_string(),
             description: "1 is the worst, 5 is the best".to_string(),
-            max_rating: 5
-        }.into(),
-    ].into_iter().map(|q| {
-        SurveyQuestion {
-            uuid: uuid::Uuid::new_v4(),
-            required: false,
-            question: q,
+            max_rating: 5,
         }
-    }).collect::<Vec<_>>();
+        .into(),
+    ]
+    .into_iter()
+    .map(|q| SurveyQuestion {
+        uuid: uuid::Uuid::new_v4(),
+        required: false,
+        question: q,
+    })
+    .collect::<Vec<_>>();
 
     let db_name = create_db_for_tests();
     let client = Client::untracked(bench_rocket(&db_name)).expect("valid rocket instance");
     let token = create_test_user(&client);
-    fn make_test_survey(client: &Client, token: &String, questions: &Vec<SurveyQuestion>, mut amount: usize) -> i32 {
+    fn make_test_survey(
+        client: &Client,
+        token: &String,
+        questions: &Vec<SurveyQuestion>,
+        mut amount: usize,
+    ) -> i32 {
         let survey_id = make_survey(&client, &token);
         let mut q = vec![];
         while amount > questions.len() {
@@ -70,11 +80,14 @@ fn get_survey(c: &mut Criterion) {
 
     for survey_size in [2, 4, 8, 16, 32].iter() {
         let survey_id = make_test_survey(&client, &token, &questions, *survey_size);
-        c.bench_function(&format!("get survey: {} questions", survey_size), |b| b.iter(|| {
-            let resp = client.get(uri!("/api", api_server::survey::get_survey(survey_id)).to_string())
-                .dispatch();
-            black_box(resp);
-        }));
+        c.bench_function(&format!("get survey: {} questions", survey_size), |b| {
+            b.iter(|| {
+                let resp = client
+                    .get(uri!("/api", api_server::survey::get_survey(survey_id)).to_string())
+                    .dispatch();
+                black_box(resp);
+            })
+        });
     }
 
     drop_test_db(db_name);
@@ -86,38 +99,49 @@ fn patch_survey(c: &mut Criterion) {
             prompt: "What is your name?".to_string(),
             description: "Please enter your name".to_string(),
             multiline: false,
-        }.into(),
+        }
+        .into(),
         QRating {
             prompt: "Rate the foobar".to_string(),
             description: "1 is the worst, 5 is the best".to_string(),
-            max_rating: 5
-        }.into(),
+            max_rating: 5,
+        }
+        .into(),
         QMultipleChoice {
             prompt: "Pick one".to_string(),
             description: "yes".to_string(),
-        }.into(),
+        }
+        .into(),
         QText {
             prompt: "What is your name?".to_string(),
             description: "Please enter your name".to_string(),
             multiline: true,
-        }.into(),
+        }
+        .into(),
         QRating {
             prompt: "Rate the foobar".to_string(),
             description: "1 is the worst, 5 is the best".to_string(),
-            max_rating: 5
-        }.into(),
-    ].into_iter().map(|q| {
-        SurveyQuestion {
-            uuid: uuid::Uuid::new_v4(),
-            required: false,
-            question: q,
+            max_rating: 5,
         }
-    }).collect::<Vec<_>>();
+        .into(),
+    ]
+    .into_iter()
+    .map(|q| SurveyQuestion {
+        uuid: uuid::Uuid::new_v4(),
+        required: false,
+        question: q,
+    })
+    .collect::<Vec<_>>();
 
     let db_name = create_db_for_tests();
     let client = Client::untracked(bench_rocket(&db_name)).expect("valid rocket instance");
     let token = create_test_user(&client);
-    fn make_test_survey(client: &Client, token: &String, questions: &Vec<SurveyQuestion>, mut amount: usize) -> (i32, Vec<u8>) {
+    fn make_test_survey(
+        client: &Client,
+        token: &String,
+        questions: &Vec<SurveyQuestion>,
+        mut amount: usize,
+    ) -> (i32, Vec<u8>) {
         let survey_id = make_survey(&client, &token);
         let mut q = vec![];
         while amount > questions.len() {
@@ -139,15 +163,17 @@ fn patch_survey(c: &mut Criterion) {
     for survey_size in [2, 4, 8, 16, 32].iter() {
         let (survey_id, body) = make_test_survey(&client, &token, &questions, *survey_size);
 
-        c.bench_function(&format!("patch survey: {} questions", survey_size), |b| b.iter(|| {
-            let resp = client.get(uri!("/api", api_server::survey::edit_survey(survey_id))
-            .to_string())
-            .header(rocket::http::ContentType::JSON)
-            .header(rocket::http::Header::new("Authorization", token.clone()))
-            .body(body.clone())
-                .dispatch();
-            black_box(resp);
-        }));
+        c.bench_function(&format!("patch survey: {} questions", survey_size), |b| {
+            b.iter(|| {
+                let resp = client
+                    .get(uri!("/api", api_server::survey::edit_survey(survey_id)).to_string())
+                    .header(rocket::http::ContentType::JSON)
+                    .header(rocket::http::Header::new("Authorization", token.clone()))
+                    .body(body.clone())
+                    .dispatch();
+                black_box(resp);
+            })
+        });
     }
 
     drop_test_db(db_name);

--- a/crates/api_server/benches/surveys.rs
+++ b/crates/api_server/benches/surveys.rs
@@ -1,0 +1,84 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use api_server::questions::{SurveyQuestion, QText, QRating, QMultipleChoice};
+use api_server::test_helpers::*;
+use api_server::db::models::SurveyPatch;
+use rocket::local::blocking::Client;
+use rocket::uri;
+
+
+fn get_survey(c: &mut Criterion) {
+    let questions = vec![
+        QText {
+            prompt: "What is your name?".to_string(),
+            description: "Please enter your name".to_string(),
+            multiline: false,
+        }.into(),
+        QRating {
+            prompt: "Rate the foobar".to_string(),
+            description: "1 is the worst, 5 is the best".to_string(),
+            max_rating: 5
+        }.into(),
+        QMultipleChoice {
+            prompt: "Pick one".to_string(),
+            description: "yes".to_string(),
+        }.into(),
+        QText {
+            prompt: "What is your name?".to_string(),
+            description: "Please enter your name".to_string(),
+            multiline: true,
+        }.into(),
+        QRating {
+            prompt: "Rate the foobar".to_string(),
+            description: "1 is the worst, 5 is the best".to_string(),
+            max_rating: 5
+        }.into(),
+    ].into_iter().map(|q| {
+        SurveyQuestion {
+            uuid: uuid::Uuid::new_v4(),
+            required: false,
+            question: q,
+        }
+    }).collect::<Vec<_>>();
+
+    let db_name = create_db_for_tests();
+    let client = Client::untracked(test_rocket(&db_name)).expect("valid rocket instance");
+    let token = create_test_user(&client);
+    fn make_test_survey(client: &Client, token: &String, questions: &Vec<SurveyQuestion>, mut amount: usize) -> i32 {
+        let survey_id = make_survey(&client, &token);
+        let mut q = vec![];
+        while amount > questions.len() {
+            q.extend(questions.clone());
+            amount -= questions.len();
+        }
+        q.extend(questions[..amount].to_vec());
+        client
+            .patch(uri!("/api", api_server::survey::edit_survey(survey_id)).to_string())
+            .header(rocket::http::ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", token.clone()))
+            .body(
+                serde_json::to_vec(&SurveyPatch {
+                    title: Some("Benchmark Survey".to_string()),
+                    published: Some(true),
+                    questions: Some(q.into()),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .dispatch();
+        survey_id
+    }
+
+    for survey_size in [2, 4, 8, 16, 32].iter() {
+        let survey_id = make_test_survey(&client, &token, &questions, *survey_size);
+        c.bench_function(&format!("get survey: {} questions", survey_size), |b| b.iter(|| {
+            let resp = client.get(uri!("/api", api_server::survey::get_survey(survey_id)).to_string())
+                .dispatch();
+            black_box(resp);
+        }));
+    }
+
+    drop_test_db(db_name);
+}
+
+criterion_group!(benches, get_survey);
+criterion_main!(benches);

--- a/crates/api_server/src/db/mod.rs
+++ b/crates/api_server/src/db/mod.rs
@@ -7,8 +7,7 @@ use rocket_sync_db_pools::database;
 pub mod models;
 pub mod schema;
 
-#[cfg_attr(not(test), database("survey_app"))]
-#[cfg_attr(test, database("survey_app_test"))]
+#[database("survey_app")]
 pub struct Storage(rocket_sync_db_pools::diesel::PgConnection);
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");

--- a/crates/api_server/src/db/models.rs
+++ b/crates/api_server/src/db/models.rs
@@ -80,6 +80,18 @@ pub struct ListedSurvey {
 #[typeshare(serialized_as = "Vec<SurveyQuestion>")]
 pub struct SurveyQuestions(pub Vec<SurveyQuestion>);
 
+impl From<Vec<SurveyQuestion>> for SurveyQuestions {
+    fn from(v: Vec<SurveyQuestion>) -> Self {
+        Self(v)
+    }
+}
+
+impl From<SurveyQuestions> for Vec<SurveyQuestion> {
+    fn from(v: SurveyQuestions) -> Self {
+        v.0
+    }
+}
+
 impl FromSql<Jsonb, Pg> for SurveyQuestions {
     fn from_sql(value: PgValue) -> diesel::deserialize::Result<Self> {
         let value = <serde_json::Value as FromSql<Jsonb, Pg>>::from_sql(value)?;

--- a/crates/api_server/src/lib.rs
+++ b/crates/api_server/src/lib.rs
@@ -6,13 +6,13 @@ extern crate typeshare;
 extern crate diesel;
 
 pub mod api;
-mod db;
+pub mod db;
 pub mod jwt;
-mod questions;
-mod survey;
-#[cfg(test)]
-mod test_helpers;
-mod user;
+pub mod questions;
+pub mod survey;
+// #[cfg(any(test, bench))]
+pub mod test_helpers;
+pub mod user;
 
 #[get("/")]
 fn index() -> &'static str {

--- a/crates/api_server/src/questions.rs
+++ b/crates/api_server/src/questions.rs
@@ -22,23 +22,41 @@ pub enum Question {
 #[typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QText {
-    prompt: String,
-    description: String,
-    multiline: bool,
+    pub prompt: String,
+    pub description: String,
+    pub multiline: bool,
 }
 
 /// Represents a question like "On a scale of 1 to N, how do you feel about X?"
 #[typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QRating {
-    prompt: String,
-    description: String,
-    max_rating: u8,
+    pub prompt: String,
+    pub description: String,
+    pub max_rating: u8,
 }
 
 #[typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QMultipleChoice {
-    prompt: String,
-    description: String,
+    pub prompt: String,
+    pub description: String,
+}
+
+impl From<QText> for Question {
+    fn from(q: QText) -> Self {
+        Self::Text(q)
+    }
+}
+
+impl From<QRating> for Question {
+    fn from(q: QRating) -> Self {
+        Self::Rating(q)
+    }
+}
+
+impl From<QMultipleChoice> for Question {
+    fn from(q: QMultipleChoice) -> Self {
+        Self::MultipleChoice(q)
+    }
 }

--- a/crates/api_server/src/test_helpers.rs
+++ b/crates/api_server/src/test_helpers.rs
@@ -66,10 +66,23 @@ pub fn test_rocket(db_name: &String) -> rocket::Rocket<rocket::Build> {
         .figment()
         .clone()
         .merge((
-            "databases.survey_app_test.url",
+            "databases.survey_app.url",
             format!("postgres://vscode:notsecure@db/{}", db_name),
         ))
-        .merge(("databases.survey_app_test.pool_size", 1))
+        .merge(("databases.survey_app.pool_size", 1));
+    return rocket.configure(config);
+}
+
+pub fn bench_rocket(db_name: &String) -> rocket::Rocket<rocket::Build> {
+    let rocket = crate::rocket();
+    let config = rocket
+        .figment()
+        .clone()
+        .merge((
+            "databases.survey_app.url",
+            format!("postgres://vscode:notsecure@db/{}", db_name),
+        ))
+        .merge(("databases.survey_app.pool_size", 5))
         .merge(("secret_key", vec![12u8; 64]));
     return rocket.configure(config);
 }

--- a/crates/api_server/src/test_helpers.rs
+++ b/crates/api_server/src/test_helpers.rs
@@ -21,9 +21,7 @@ pub fn drop_test_db(db_name: String) {
     let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
         .expect("Failed to connect to database");
     sql_query(format!(
-        "SELECT pg_terminate_backend(pg_stat_activity.pid FROM pg_stat_activity
-            WHERE pg_stat_activity.datname = '{db_name}'
-            AND pid <> pg_backend_pid();"
+        "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '{db_name}' AND pid <> pg_backend_pid();"
     ))
     .execute(&mut conn)
     .expect("Failed to kill connections to test database");

--- a/crates/api_server/src/test_helpers.rs
+++ b/crates/api_server/src/test_helpers.rs
@@ -20,6 +20,13 @@ pub fn create_db_for_tests() -> String {
 pub fn drop_test_db(db_name: String) {
     let mut conn = PgConnection::establish("postgres://vscode:notsecure@db/survey_app")
         .expect("Failed to connect to database");
+    sql_query(format!(
+        "SELECT pg_terminate_backend(pg_stat_activity.pid FROM pg_stat_activity
+            WHERE pg_stat_activity.datname = '{db_name}'
+            AND pid <> pg_backend_pid();"
+    ))
+    .execute(&mut conn)
+    .expect("Failed to kill connections to test database");
     sql_query(format!("DROP DATABASE IF EXISTS {db_name}"))
         .execute(&mut conn)
         .expect("Failed to drop test database");

--- a/crates/api_server/src/test_helpers.rs
+++ b/crates/api_server/src/test_helpers.rs
@@ -82,7 +82,7 @@ pub fn bench_rocket(db_name: &String) -> rocket::Rocket<rocket::Build> {
             "databases.survey_app.url",
             format!("postgres://vscode:notsecure@db/{}", db_name),
         ))
-        .merge(("databases.survey_app.pool_size", 5))
+        .merge(("databases.survey_app.pool_size", 1))
         .merge(("secret_key", vec![12u8; 64]));
     return rocket.configure(config);
 }

--- a/crates/api_server/src/test_helpers.rs
+++ b/crates/api_server/src/test_helpers.rs
@@ -69,7 +69,8 @@ pub fn test_rocket(db_name: &String) -> rocket::Rocket<rocket::Build> {
             "databases.survey_app_test.url",
             format!("postgres://vscode:notsecure@db/{}", db_name),
         ))
-        .merge(("databases.survey_app_test.pool_size", 1));
+        .merge(("databases.survey_app_test.pool_size", 1))
+        .merge(("secret_key", vec![12u8; 64]));
     return rocket.configure(config);
 }
 

--- a/crates/api_server_bin/Cargo.toml
+++ b/crates/api_server_bin/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "api_server_bin"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+api_server = { path = "../api_server" }

--- a/crates/api_server_bin/src/main.rs
+++ b/crates/api_server_bin/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    api_server::main();
+}


### PR DESCRIPTION
- add benchmark module with get survey benchmark
- fix benchmarks using real db, refactor how test_rocket works to be less complicated
- add patch survey benchmark
- set connection pool size to 1 for benchmarks
- kill all connections to test db before attempting to drop it
- format
- fix syntax error


This sets up benchmarks that can be run with `cargo bench`.

Requires #45 to be merged in first so I can rebase.
