### PR TITLE
client side JWT store and API helpers

### DIFF
--- a/crates/api_server/src/api.rs
+++ b/crates/api_server/src/api.rs
@@ -5,6 +5,7 @@ use rocket::request::Request;
 use rocket::response::{self, Responder, Response};
 use serde::Serialize;
 
+#[typeshare]
 #[derive(Debug, Clone, Serialize)]
 pub struct ApiErrorResponse<R> {
     #[serde(skip)]

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,0 +1,74 @@
+/**
+ * Provides a type-checked API for interacting with the backend.
+ *
+ * Basically just a thin wrapper around fetch() that adds type checking.
+ */
+
+import type { Survey, ApiErrorResponse, SurveyPatch, UserLoginParams, UserToken } from './common';
+import { jwt } from '../stores';
+
+const API_URL = 'http://localhost:5347'; // TODO: see #42
+
+export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+export type ApiResponse<T> = Result<T, ApiErrorResponse<any>>;
+
+async function apiReq<T>(path: string, options?: RequestInit | undefined): Promise<ApiResponse<T>> {
+	let response = await fetch(`${API_URL}${path}`, options);
+
+	let apiResponse: ApiResponse<T>;
+	if (response.ok) {
+		apiResponse = { ok: true, value: await response.json() };
+	} else {
+		apiResponse = { ok: false, error: await response.json() };
+	}
+	return apiResponse;
+}
+
+async function apiReqAuth<T>(
+	path: string,
+	options?: RequestInit | undefined
+): Promise<ApiResponse<T>> {
+	let token = jwt.get();
+	if (!token) {
+		throw new Error(`Not logged in, cannot make authenticated request to ${path}`);
+	}
+	return apiReq(path, {
+		...options,
+		headers: {
+			...options?.headers,
+			Authorization: `Bearer ${token}`
+		}
+	});
+}
+
+export async function loginUser(params: UserLoginParams): Promise<ApiResponse<UserToken>> {
+	return apiReq(`/api/user/login`, {
+		method: 'POST',
+		body: JSON.stringify(params)
+	});
+}
+
+export async function registerUser(params: UserLoginParams): Promise<ApiResponse<UserToken>> {
+	return apiReq(`/api/user/register`, {
+		method: 'POST',
+		body: JSON.stringify(params)
+	});
+}
+
+export async function getSurvey(survey_id: number): Promise<ApiResponse<Survey>> {
+	return apiReq(`/api/survey/${survey_id}`);
+}
+
+export async function createSurvey(): Promise<ApiResponse<Survey>> {
+	return apiReqAuth(`/api/survey/create`, { method: 'POST' });
+}
+
+export async function editSurvey(
+	survey_id: number,
+	survey: SurveyPatch
+): Promise<ApiResponse<Survey>> {
+	return apiReqAuth(`/api/survey/${survey_id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(survey)
+	});
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -13,7 +13,7 @@ export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
 export type ApiResponse<T> = Result<T, ApiErrorResponse<any>>;
 
 async function apiReq<T>(path: string, options?: RequestInit | undefined): Promise<ApiResponse<T>> {
-	let response = await fetch(`${API_URL}${path}`, options);
+	const response = await fetch(`${API_URL}${path}`, options);
 
 	let apiResponse: ApiResponse<T>;
 	if (response.ok) {
@@ -28,7 +28,7 @@ async function apiReqAuth<T>(
 	path: string,
 	options?: RequestInit | undefined
 ): Promise<ApiResponse<T>> {
-	let token = jwt.get();
+	const token = jwt.get();
 	if (!token) {
 		throw new Error(`Not logged in, cannot make authenticated request to ${path}`);
 	}

--- a/packages/frontend/src/lib/common.ts
+++ b/packages/frontend/src/lib/common.ts
@@ -4,6 +4,10 @@
 
 export type SurveyQuestions = SurveyQuestion[];
 
+export interface ApiErrorResponse<R> {
+	message: R;
+}
+
 export interface Survey {
 	id: number;
 	title: string;

--- a/packages/frontend/src/stores.test.ts
+++ b/packages/frontend/src/stores.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { jwt } from './stores';
+
+const localStorageMock = (function () {
+	var store: { [key: string]: string | null } = {};
+
+	return {
+		getItem(key: string): string | null {
+			return store[key] || null;
+		},
+		setItem(key: string, value: string | null) {
+			if (!value) {
+				delete store[key];
+				return;
+			}
+			store[key] = value.toString();
+		},
+		removeItem(key: string) {
+			delete store[key];
+		},
+		clear() {
+			store = {};
+		}
+	};
+})();
+
+Object.defineProperty(global, 'localStorage', {
+	value: localStorageMock
+});
+
+describe('jwt store', () => {
+	it('should store token in localStorage', () => {
+		jwt.login('foo');
+
+		expect(localStorage.getItem('token')).toEqual('foo');
+	});
+
+	it('should remove token on logout', () => {
+		localStorage.setItem('token', 'foo');
+		jwt.logout();
+
+		expect(localStorage.getItem('token')).toEqual(null);
+	});
+
+	it('should get token', () => {
+		jwt.login('foo');
+
+		expect(jwt.get()).toEqual('foo');
+	});
+});

--- a/packages/frontend/src/stores.test.ts
+++ b/packages/frontend/src/stores.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { jwt } from './stores';
 
 const localStorageMock = (function () {
-	var store: { [key: string]: string | null } = {};
+	let store: { [key: string]: string | null } = {};
 
 	return {
 		getItem(key: string): string | null {

--- a/packages/frontend/src/stores.ts
+++ b/packages/frontend/src/stores.ts
@@ -1,0 +1,38 @@
+import { writable } from 'svelte/store';
+
+function createJWTStore() {
+	const { set: innerset } = writable<string | undefined>(undefined);
+
+	function set(value: string | undefined) {
+		innerset(value);
+		if (value === undefined) {
+			localStorage.removeItem('token');
+			return;
+		}
+		localStorage.setItem('token', value);
+	}
+
+	function get(): string | undefined {
+		const token = localStorage.getItem('token');
+		if (token === null) {
+			return undefined;
+		}
+		return token;
+	}
+
+	function login(token: string) {
+		set(token);
+	}
+
+	function logout() {
+		set(undefined);
+	}
+
+	return {
+		get,
+		login,
+		logout
+	};
+}
+
+export const jwt = createJWTStore();


### PR DESCRIPTION
- add jwt store
- share ApiErrorResponse type
- add api module to interact with the backend in a type-checked way

closes #46
