### PR TITLE
Validate Survey Responses

### DIFF
--- a/crates/api_server/benches/responses.rs
+++ b/crates/api_server/benches/responses.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use api_server::db::models::{SurveyPatch, SurveyQuestions};
-use api_server::questions::{QRating, QText, QMultipleChoice, Choice, SurveyQuestion};
+use api_server::questions::{Choice, QMultipleChoice, QRating, QText, SurveyQuestion};
 use api_server::test_helpers::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
@@ -203,10 +203,12 @@ fn survey_response_stress(c: &mut Criterion) {
                 prompt: "Rate your food.".to_string(),
                 description: "please".to_string(),
                 multiple: true,
-                choices: (0u64..10).map(|n| Choice {
-                    uuid: Uuid::from_u128(n.into()),
-                    text: format!("Choice {n}"),
-                }).collect(),
+                choices: (0u64..10)
+                    .map(|n| Choice {
+                        uuid: Uuid::from_u128(n.into()),
+                        text: format!("Choice {n}"),
+                    })
+                    .collect(),
             }
             .into(),
         },
@@ -217,10 +219,12 @@ fn survey_response_stress(c: &mut Criterion) {
                 prompt: "Rate your fun.".to_string(),
                 description: "please".to_string(),
                 multiple: false,
-                choices: (0u64..10).map(|n| Choice {
-                    uuid: Uuid::from_u128(n.into()),
-                    text: format!("Choice {n}"),
-                }).collect(),
+                choices: (0u64..10)
+                    .map(|n| Choice {
+                        uuid: Uuid::from_u128(n.into()),
+                        text: format!("Choice {n}"),
+                    })
+                    .collect(),
             }
             .into(),
         },

--- a/crates/api_server/benches/responses.rs
+++ b/crates/api_server/benches/responses.rs
@@ -1,12 +1,13 @@
 use std::str::FromStr;
 
 use api_server::db::models::{SurveyPatch, SurveyQuestions};
-use api_server::questions::{QRating, QText, SurveyQuestion};
+use api_server::questions::{QRating, QText, QMultipleChoice, Choice, SurveyQuestion};
 use api_server::test_helpers::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 use rocket::local::blocking::Client;
 use rocket::uri;
+use uuid::Uuid;
 
 fn make_test_survey(client: &Client, questions: SurveyQuestions) -> i32 {
     let token = create_test_user(client);
@@ -80,6 +81,7 @@ fn survey_text_questions(c: &mut Criterion) {
                     .unwrap(),
                 )
                 .dispatch();
+            assert_eq!(resp.status(), rocket::http::Status::Ok);
             black_box(resp);
         });
     });
@@ -149,9 +151,144 @@ fn survey_rating_questions(c: &mut Criterion) {
     drop_test_db(db_name)
 }
 
+fn survey_response_stress(c: &mut Criterion) {
+    let db_name = create_db_for_tests();
+    let client = Client::untracked(bench_rocket(&db_name)).expect("valid rocket instance");
+
+    let questions: SurveyQuestions = vec![
+        SurveyQuestion {
+            uuid: uuid::Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap(),
+            required: true,
+            question: QText {
+                prompt: "What is your name?".to_string(),
+                description: "Please enter your name".to_string(),
+                multiline: false,
+            }
+            .into(),
+        },
+        SurveyQuestion {
+            uuid: uuid::Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap(),
+            required: true,
+            question: QText {
+                prompt: "Describe your shoes".to_string(),
+                description: "please".to_string(),
+                multiline: true,
+            }
+            .into(),
+        },
+        SurveyQuestion {
+            uuid: uuid::Uuid::from_str("00000000-0000-0000-0000-000000000002").unwrap(),
+            required: true,
+            question: QRating {
+                prompt: "Rate your food.".to_string(),
+                description: "please".to_string(),
+                max_rating: 5,
+            }
+            .into(),
+        },
+        SurveyQuestion {
+            uuid: uuid::Uuid::from_str("00000000-0000-0000-0000-000000000003").unwrap(),
+            required: true,
+            question: QRating {
+                prompt: "Rate your fun.".to_string(),
+                description: "please".to_string(),
+                max_rating: 5,
+            }
+            .into(),
+        },
+        SurveyQuestion {
+            uuid: uuid::Uuid::from_str("00000000-0000-0000-0000-000000000004").unwrap(),
+            required: true,
+            question: QMultipleChoice {
+                prompt: "Rate your food.".to_string(),
+                description: "please".to_string(),
+                multiple: true,
+                choices: (0u64..10).map(|n| Choice {
+                    uuid: Uuid::from_u128(n.into()),
+                    text: format!("Choice {n}"),
+                }).collect(),
+            }
+            .into(),
+        },
+        SurveyQuestion {
+            uuid: uuid::Uuid::from_str("00000000-0000-0000-0000-000000000005").unwrap(),
+            required: true,
+            question: QMultipleChoice {
+                prompt: "Rate your fun.".to_string(),
+                description: "please".to_string(),
+                multiple: false,
+                choices: (0u64..10).map(|n| Choice {
+                    uuid: Uuid::from_u128(n.into()),
+                    text: format!("Choice {n}"),
+                }).collect(),
+            }
+            .into(),
+        },
+    ]
+    .into();
+    let survey_id = make_test_survey(&client, questions);
+
+    c.bench_function("survey response stress test", |b| {
+        b.iter(|| {
+            let resp = client
+                .post(uri!(
+                    "/api",
+                    api_server::survey_response::create_survey_response(survey_id)
+                ))
+                .header(rocket::http::ContentType::JSON)
+                .body(
+                    serde_json::to_vec(&serde_json::json!({
+                        "00000000-0000-0000-0000-000000000000": {
+                            "type": "Text",
+                            "content": {
+                                "text": "test"
+                            }
+                        },
+                        "00000000-0000-0000-0000-000000000001": {
+                            "type": "Text",
+                            "content": {
+                                "text": "test"
+                            }
+                        },
+                        "00000000-0000-0000-0000-000000000002": {
+                            "type": "Rating",
+                            "content": {
+                                "rating": 4
+                            }
+                        },
+                        "00000000-0000-0000-0000-000000000003": {
+                            "type": "Rating",
+                            "content": {
+                                "rating": 4
+                            }
+                        },
+                        "00000000-0000-0000-0000-000000000004": {
+                            "type": "MultipleChoice",
+                            "content": {
+                                "selected": ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003", "00000000-0000-0000-0000-000000000004", "00000000-0000-0000-0000-000000000005", "00000000-0000-0000-0000-000000000006", "00000000-0000-0000-0000-000000000007", "00000000-0000-0000-0000-000000000008", "00000000-0000-0000-0000-000000000009"]
+                            }
+                        },
+                        "00000000-0000-0000-0000-000000000005": {
+                            "type": "MultipleChoice",
+                            "content": {
+                                "selected": ["00000000-0000-0000-0000-000000000000"]
+                            }
+                        }
+                    }))
+                    .unwrap(),
+                )
+                .dispatch();
+            assert_eq!(resp.status(), rocket::http::Status::Ok);
+            black_box(resp);
+        });
+    });
+
+    drop_test_db(db_name)
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = survey_text_questions, survey_rating_questions
+    targets = survey_text_questions, survey_rating_questions, survey_response_stress
 }
 criterion_main!(benches);

--- a/crates/api_server/src/questions.rs
+++ b/crates/api_server/src/questions.rs
@@ -115,3 +115,35 @@ impl From<RMultipleChoice> for Response {
         Self::MultipleChoice(r)
     }
 }
+
+pub(crate) trait IsEmpty {
+    fn is_empty(&self) -> bool;
+}
+
+impl IsEmpty for Response {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Text(r) => r.is_empty(),
+            Self::Rating(r) => r.is_empty(),
+            Self::MultipleChoice(r) => r.is_empty(),
+        }
+    }
+}
+
+impl IsEmpty for RText {
+    fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+}
+
+impl IsEmpty for RRating {
+    fn is_empty(&self) -> bool {
+        self.rating == 0
+    }
+}
+
+impl IsEmpty for RMultipleChoice {
+    fn is_empty(&self) -> bool {
+        self.selected.is_empty()
+    }
+}

--- a/crates/api_server/src/survey.rs
+++ b/crates/api_server/src/survey.rs
@@ -46,6 +46,12 @@ impl From<SurveyError> for ApiErrorResponse<SurveyError> {
     }
 }
 
+impl From<Vec<ValidationError>> for ApiErrorResponse<SurveyError> {
+    fn from(value: Vec<ValidationError>) -> Self {
+        SurveyError::ValidationError(value).into()
+    }
+}
+
 #[post("/survey/create")]
 pub async fn create_survey(
     claims: Claims,
@@ -133,9 +139,7 @@ pub async fn edit_survey(
         return Err(SurveyError::CantEditPublished.into());
     }
 
-    new_survey
-        .validate()
-        .map_err(SurveyError::ValidationError)?;
+    new_survey.validate()?;
 
     db.run(move |conn| -> anyhow::Result<()> {
         diesel::update(schema::surveys::table)

--- a/crates/api_server/src/survey.rs
+++ b/crates/api_server/src/survey.rs
@@ -153,7 +153,7 @@ pub async fn edit_survey(
     Ok(())
 }
 
-async fn get_survey_from_db(db: &Storage, survey_id: i32) -> anyhow::Result<Survey> {
+pub(crate) async fn get_survey_from_db(db: &Storage, survey_id: i32) -> anyhow::Result<Survey> {
     db.run(move |conn| {
         let survey = schema::surveys::dsl::surveys
             .find(survey_id)

--- a/crates/api_server/src/survey_response.rs
+++ b/crates/api_server/src/survey_response.rs
@@ -7,9 +7,10 @@ use uuid::Uuid;
 use crate::{
     api::ApiErrorResponse,
     db::{
-        models::{NewSurveyResponse, PatchSurveyResponse, SurveyResponse, SurveyResponses, Survey},
+        models::{NewSurveyResponse, PatchSurveyResponse, Survey, SurveyResponse, SurveyResponses},
         Storage,
-    }, validate::{Validate, ValidationError},
+    },
+    validate::{Validate, ValidationError},
 };
 
 #[typeshare]
@@ -49,13 +50,10 @@ impl From<SurveyResponseError> for ApiErrorResponse<SurveyResponseError> {
     }
 }
 
-async fn get_survey_from_db(
-    db: &Storage,
-    survey_id: i32,
-) -> Result<Survey, SurveyResponseError> {
-    let survey = crate::survey::get_survey_from_db(&db, survey_id).await.map_err(|_| {
-        SurveyResponseError::SurveyNotFound
-    })?;
+async fn get_survey_from_db(db: &Storage, survey_id: i32) -> Result<Survey, SurveyResponseError> {
+    let survey = crate::survey::get_survey_from_db(&db, survey_id)
+        .await
+        .map_err(|_| SurveyResponseError::SurveyNotFound)?;
 
     if !survey.published {
         return Err(SurveyResponseError::SurveyNotPublished);

--- a/crates/api_server/src/survey_response.rs
+++ b/crates/api_server/src/survey_response.rs
@@ -73,7 +73,7 @@ pub async fn create_survey_response(
     let survey_responses = survey_response.into_inner();
     (&survey.questions, &survey_responses)
         .validate()
-        .map_err(|e| SurveyResponseError::ValidationError(e))?;
+        .map_err(SurveyResponseError::ValidationError)?;
 
     let uuid = db
         .run(move |conn| {

--- a/crates/api_server/src/survey_response.rs
+++ b/crates/api_server/src/survey_response.rs
@@ -57,7 +57,7 @@ impl From<Vec<ValidationError>> for ApiErrorResponse<SurveyResponseError> {
 }
 
 async fn get_survey_from_db(db: &Storage, survey_id: i32) -> Result<Survey, SurveyResponseError> {
-    let survey = crate::survey::get_survey_from_db(&db, survey_id)
+    let survey = crate::survey::get_survey_from_db(db, survey_id)
         .await
         .map_err(|_| SurveyResponseError::SurveyNotFound)?;
 

--- a/crates/api_server/src/validate.rs
+++ b/crates/api_server/src/validate.rs
@@ -231,7 +231,7 @@ impl Validate for (&SurveyQuestions, &SurveyResponses) {
 
         // Check that all responses have a corresponding question
         let question_uuids = questions.iter().map(|q| q.uuid).collect::<Vec<_>>();
-        for (q_uuid, _) in responses {
+        for q_uuid in responses.keys() {
             if !question_uuids.contains(q_uuid) {
                 errors.push(ValidationError::NotFound {
                     field: "response".to_string(),
@@ -366,7 +366,7 @@ impl Validate for (&QMultipleChoice, &RMultipleChoice) {
             if !question.choices.iter().any(|c| c.uuid == *choice) {
                 errors.push(ValidationError::NotFound {
                     field: "selected".to_string(),
-                    uuid: choice.clone(),
+                    uuid: *choice,
                 });
             }
         }

--- a/crates/api_server/src/validate.rs
+++ b/crates/api_server/src/validate.rs
@@ -215,28 +215,112 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn prompts_should_be_required() {
-        let qs: Vec<Question> = vec![
-            QText {
-                prompt: "".to_owned(),
-                description: "".to_owned(),
-                multiline: false,
+    mod surveys {
+        use super::*;
+
+        #[test]
+        fn prompts_should_be_required() {
+            let qs: Vec<Question> = vec![
+                QText {
+                    prompt: "".to_owned(),
+                    description: "".to_owned(),
+                    multiline: false,
+                }
+                .into(),
+                QRating {
+                    prompt: "".to_owned(),
+                    description: "".to_owned(),
+                    max_rating: 5,
+                }
+                .into(),
+                QMultipleChoice {
+                    prompt: "".to_owned(),
+                    description: "".to_owned(),
+                    choices: vec![
+                        Choice {
+                            uuid: Uuid::new_v4(),
+                            text: "Choice 1".to_owned(),
+                        },
+                        Choice {
+                            uuid: Uuid::new_v4(),
+                            text: "Choice 2".to_owned(),
+                        },
+                    ],
+                    multiple: false,
+                }
+                .into(),
+            ];
+            let errors = qs
+                .iter()
+                .flat_map(|q| q.validate().unwrap_err())
+                .collect::<Vec<_>>();
+            for (i, error) in errors.iter().enumerate() {
+                match error {
+                    ValidationError::Required { field } => {
+                        assert!(field == "prompt");
+                    }
+                    _ => panic!("Unexpected error at {i}: {error:?}"),
+                }
             }
-            .into(),
-            QRating {
-                prompt: "".to_owned(),
+            assert_eq!(errors.len(), 3);
+        }
+
+        #[test]
+        fn max_rating_should_be_in_range() {
+            let q = QRating {
+                prompt: "Prompt".to_owned(),
                 description: "".to_owned(),
-                max_rating: 5,
+                max_rating: 1,
+            };
+            let errors = q.validate().unwrap_err();
+            for (i, error) in errors.iter().enumerate() {
+                match error {
+                    ValidationError::NotInRange {
+                        field,
+                        value,
+                        min,
+                        max,
+                    } => {
+                        assert!(field == "max_rating");
+                        assert_eq!(*value, 1);
+                        assert_eq!(*min, 2);
+                        assert_eq!(*max, 10);
+                    }
+                    _ => panic!("Unexpected error at {i}: {error:?}"),
+                }
             }
-            .into(),
-            QMultipleChoice {
-                prompt: "".to_owned(),
+            assert_eq!(errors.len(), 1);
+        }
+
+        #[test]
+        fn choices_should_be_required() {
+            let q = QMultipleChoice {
+                prompt: "Prompt".to_owned(),
+                description: "".to_owned(),
+                choices: vec![],
+                multiple: false,
+            };
+            let errors = q.validate().unwrap_err();
+            for (i, error) in errors.iter().enumerate() {
+                match error {
+                    ValidationError::Required { field } => {
+                        assert!(field == "choices");
+                    }
+                    _ => panic!("Unexpected error at {i}: {error:?}"),
+                }
+            }
+            assert_eq!(errors.len(), 1);
+        }
+
+        #[test]
+        fn choice_text_should_be_required() {
+            let q = QMultipleChoice {
+                prompt: "Prompt".to_owned(),
                 description: "".to_owned(),
                 choices: vec![
                     Choice {
                         uuid: Uuid::new_v4(),
-                        text: "Choice 1".to_owned(),
+                        text: "".to_owned(),
                     },
                     Choice {
                         uuid: Uuid::new_v4(),
@@ -244,191 +328,111 @@ mod tests {
                     },
                 ],
                 multiple: false,
-            }
-            .into(),
-        ];
-        let errors = qs
-            .iter()
-            .flat_map(|q| q.validate().unwrap_err())
-            .collect::<Vec<_>>();
-        for (i, error) in errors.iter().enumerate() {
-            match error {
-                ValidationError::Required { field } => {
-                    assert!(field == "prompt");
-                }
-                _ => panic!("Unexpected error at {i}: {error:?}"),
-            }
-        }
-        assert_eq!(errors.len(), 3);
-    }
-
-    #[test]
-    fn max_rating_should_be_in_range() {
-        let q = QRating {
-            prompt: "Prompt".to_owned(),
-            description: "".to_owned(),
-            max_rating: 1,
-        };
-        let errors = q.validate().unwrap_err();
-        for (i, error) in errors.iter().enumerate() {
-            match error {
-                ValidationError::NotInRange {
-                    field,
-                    value,
-                    min,
-                    max,
-                } => {
-                    assert!(field == "max_rating");
-                    assert_eq!(*value, 1);
-                    assert_eq!(*min, 2);
-                    assert_eq!(*max, 10);
-                }
-                _ => panic!("Unexpected error at {i}: {error:?}"),
-            }
-        }
-        assert_eq!(errors.len(), 1);
-    }
-
-    #[test]
-    fn choices_should_be_required() {
-        let q = QMultipleChoice {
-            prompt: "Prompt".to_owned(),
-            description: "".to_owned(),
-            choices: vec![],
-            multiple: false,
-        };
-        let errors = q.validate().unwrap_err();
-        for (i, error) in errors.iter().enumerate() {
-            match error {
-                ValidationError::Required { field } => {
-                    assert!(field == "choices");
-                }
-                _ => panic!("Unexpected error at {i}: {error:?}"),
-            }
-        }
-        assert_eq!(errors.len(), 1);
-    }
-
-    #[test]
-    fn choice_text_should_be_required() {
-        let q = QMultipleChoice {
-            prompt: "Prompt".to_owned(),
-            description: "".to_owned(),
-            choices: vec![
-                Choice {
-                    uuid: Uuid::new_v4(),
-                    text: "".to_owned(),
-                },
-                Choice {
-                    uuid: Uuid::new_v4(),
-                    text: "Choice 2".to_owned(),
-                },
-            ],
-            multiple: false,
-        };
-        let errors = q.validate().unwrap_err();
-        for (i, error) in errors.iter().enumerate() {
-            match error {
-                ValidationError::Inner {
-                    field,
-                    uuid: _,
-                    inner,
-                } => {
-                    assert!(field == "choices");
-                    match inner.as_ref() {
-                        ValidationError::Required { field } => {
-                            assert!(field == "text");
+            };
+            let errors = q.validate().unwrap_err();
+            for (i, error) in errors.iter().enumerate() {
+                match error {
+                    ValidationError::Inner {
+                        field,
+                        uuid: _,
+                        inner,
+                    } => {
+                        assert!(field == "choices");
+                        match inner.as_ref() {
+                            ValidationError::Required { field } => {
+                                assert!(field == "text");
+                            }
+                            _ => panic!("Unexpected error at {i}: {error:?}"),
                         }
-                        _ => panic!("Unexpected error at {i}: {error:?}"),
                     }
+                    _ => panic!("Unexpected error at {i}: {error:?}"),
                 }
-                _ => panic!("Unexpected error at {i}: {error:?}"),
+            }
+            assert_eq!(errors.len(), 1);
+        }
+
+        #[test]
+        fn choice_uuids_should_be_unique() {
+            let uuid = Uuid::new_v4();
+            let q = QMultipleChoice {
+                prompt: "Prompt".to_owned(),
+                description: "".to_owned(),
+                choices: vec![
+                    Choice {
+                        uuid,
+                        text: "Choice 1".to_owned(),
+                    },
+                    Choice {
+                        uuid,
+                        text: "Choice 2".to_owned(),
+                    },
+                ],
+                multiple: false,
+            };
+            let errors = q.validate().unwrap_err();
+            for (i, error) in errors.iter().enumerate() {
+                match error {
+                    ValidationError::Inner {
+                        field,
+                        uuid: _,
+                        inner,
+                    } => {
+                        assert!(field == "choices");
+                        match inner.as_ref() {
+                            ValidationError::NotUnique { field, value } => {
+                                assert!(field == "uuid");
+                                assert_eq!(value, &uuid.to_string());
+                            }
+                            _ => panic!("Unexpected error at {i}: {error:?}"),
+                        }
+                    }
+                    _ => panic!("Unexpected error at {i}: {error:?}"),
+                }
             }
         }
-        assert_eq!(errors.len(), 1);
-    }
 
-    #[test]
-    fn choice_uuids_should_be_unique() {
-        let uuid = Uuid::new_v4();
-        let q = QMultipleChoice {
-            prompt: "Prompt".to_owned(),
-            description: "".to_owned(),
-            choices: vec![
-                Choice {
-                    uuid,
-                    text: "Choice 1".to_owned(),
-                },
-                Choice {
-                    uuid,
-                    text: "Choice 2".to_owned(),
-                },
-            ],
-            multiple: false,
-        };
-        let errors = q.validate().unwrap_err();
-        for (i, error) in errors.iter().enumerate() {
-            match error {
-                ValidationError::Inner {
-                    field,
-                    uuid: _,
-                    inner,
-                } => {
-                    assert!(field == "choices");
-                    match inner.as_ref() {
-                        ValidationError::NotUnique { field, value } => {
-                            assert!(field == "uuid");
-                            assert_eq!(value, &uuid.to_string());
+        #[test]
+        fn questions_should_be_unique() {
+            let uuid = Uuid::new_v4();
+            let q = Question::Text(QText {
+                prompt: "Prompt".to_owned(),
+                description: "".to_owned(),
+                multiline: false,
+            });
+            let qs = SurveyPatch {
+                questions: Some(SurveyQuestions(vec![
+                    SurveyQuestion {
+                        uuid,
+                        required: false,
+                        question: q.clone(),
+                    },
+                    SurveyQuestion {
+                        uuid,
+                        required: false,
+                        question: q,
+                    },
+                ])),
+                ..Default::default()
+            };
+            let errors = qs.validate().unwrap_err();
+            for (i, error) in errors.iter().enumerate() {
+                match error {
+                    ValidationError::Inner {
+                        field,
+                        uuid: _,
+                        inner,
+                    } => {
+                        assert!(field == "questions");
+                        match inner.as_ref() {
+                            ValidationError::NotUnique { field, value } => {
+                                assert!(field == "uuid");
+                                assert_eq!(value, &uuid.to_string());
+                            }
+                            _ => panic!("Unexpected error at {i}: {error:?}"),
                         }
-                        _ => panic!("Unexpected error at {i}: {error:?}"),
                     }
+                    _ => panic!("Unexpected error at {i}: {error:?}"),
                 }
-                _ => panic!("Unexpected error at {i}: {error:?}"),
-            }
-        }
-    }
-
-    #[test]
-    fn questions_should_be_unique() {
-        let uuid = Uuid::new_v4();
-        let q = Question::Text(QText {
-            prompt: "Prompt".to_owned(),
-            description: "".to_owned(),
-            multiline: false,
-        });
-        let qs = SurveyPatch {
-            questions: Some(SurveyQuestions(vec![
-                SurveyQuestion {
-                    uuid,
-                    required: false,
-                    question: q.clone(),
-                },
-                SurveyQuestion {
-                    uuid,
-                    required: false,
-                    question: q,
-                },
-            ])),
-            ..Default::default()
-        };
-        let errors = qs.validate().unwrap_err();
-        for (i, error) in errors.iter().enumerate() {
-            match error {
-                ValidationError::Inner {
-                    field,
-                    uuid: _,
-                    inner,
-                } => {
-                    assert!(field == "questions");
-                    match inner.as_ref() {
-                        ValidationError::NotUnique { field, value } => {
-                            assert!(field == "uuid");
-                            assert_eq!(value, &uuid.to_string());
-                        }
-                        _ => panic!("Unexpected error at {i}: {error:?}"),
-                    }
-                }
-                _ => panic!("Unexpected error at {i}: {error:?}"),
             }
         }
     }

--- a/packages/frontend/src/lib/common.ts
+++ b/packages/frontend/src/lib/common.ts
@@ -131,6 +131,26 @@ export type ValidationError =
 			};
 	  }
 	| {
+			type: 'NotFound';
+			data: {
+				field: string;
+				uuid: string;
+			};
+	  }
+	| {
+			type: 'MismatchedTypes';
+			data: {
+				uuid: string;
+			};
+	  }
+	| {
+			type: 'BadValue';
+			data: {
+				field: string;
+				message: string;
+			};
+	  }
+	| {
 			type: 'Inner';
 			data: {
 				/** The name of the field that failed validation. */


### PR DESCRIPTION
- move survey patch validation tests
- add IsEmpty trait for responses
- impl validate for tuples of question and response
- impl Validate for (&SurveyQuestions, &SurveyResponses)
- make it so responses get validated in the endpoint handlers
- add some tests
- add more tests
- add more tests
- generate and format
- fix some lints
- add impls from validation errors to api responses
- fix clippy lints


closes #63
