### PR TITLE
Added horizontal uniformity among button groups when in a vertical column.

### DIFF
--- a/packages/frontend/src/lib/ui/ButtonGroup.svelte
+++ b/packages/frontend/src/lib/ui/ButtonGroup.svelte
@@ -44,5 +44,6 @@
 
 	.vertical {
 		flex-direction: column;
+		align-items: stretch;
 	}
 </style>


### PR DESCRIPTION
Uses align-items: stretch on vertically aligned button groups to ensure they are all the same width as the largest button.

Closes #104