### PR TITLE
Added a onbeforeunload listener to the window in order to warn users that all data will be lost if they leave the response page.

### DIFF
--- a/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
+++ b/packages/frontend/src/routes/survey/[slug]/respond/+page.svelte
@@ -5,6 +5,7 @@
 	import type { PageData } from './$types';
 	import { goto } from '$app/navigation';
 	import { createSurveyResponse, editSurveyResponse } from '$lib/api';
+	import { browser } from '$app/environment';
 
 	export let data: PageData;
 
@@ -54,6 +55,14 @@
 			submitInProgress = false;
 		}
 	}
+
+	//alert user if leaving response page
+	if (browser) {
+		window.onbeforeunload = function () {
+			return 'Are you sure you want to leave this page? Your response will not be saved.';
+		};
+	}
+	
 </script>
 
 <h1>{survey.title}</h1>


### PR DESCRIPTION
Added an event listener to the window that alerts the user before unloading the page. This will prevent the user from accidentally leaving and losing all input data.

Closes #133