### PR TITLE
multiple selections

### DIFF
--- a/packages/frontend/src/lib/questions/QMultipleChoice.svelte
+++ b/packages/frontend/src/lib/questions/QMultipleChoice.svelte
@@ -27,6 +27,10 @@
 		dispatch('change');
 	}
 
+	$: items = choices.map((choice) => {
+		return { label: choice.text, value: choice.uuid };
+	});
+
 	export let response: Response | undefined = undefined;
 	let selected: string[] = loadResponse(response);
 
@@ -36,13 +40,15 @@
 		}
 		return [];
 	}
-	$: {
-		if (selected.length === 0) {
-			response = { type: 'MultipleChoice', content: { selected } };
+
+	function setResponse(uuids: string[]) {
+		if (uuids.length > 0) {
+			response = { type: 'MultipleChoice', content: { selected: uuids } };
 		} else {
 			response = undefined;
 		}
 	}
+	$: setResponse(selected);
 
 	export let errors: ValidationError[] = [];
 	$: validationErrors = buildErrorMapFromFields(errors);
@@ -93,14 +99,7 @@
 				<ValidationErrorRenderer {error} />
 			{/each}
 		{:else}
-			<ButtonGroup
-				orientation="vertical"
-				buttons={choices.map((choice) => {
-					return { label: choice.text, value: choice.uuid };
-				})}
-				forceSelection={false}
-				bind:selected
-			/>
+			<ButtonGroup orientation="vertical" buttons={items} forceSelection={false} bind:selected />
 			{#each validationErrors.get('response') ?? [] as error}
 				<ValidationErrorRenderer {error} />
 			{/each}

--- a/packages/frontend/src/lib/questions/QMultipleChoice.svelte
+++ b/packages/frontend/src/lib/questions/QMultipleChoice.svelte
@@ -27,23 +27,18 @@
 		dispatch('change');
 	}
 
-	let group_selected: number | undefined = undefined;
-
 	export let response: Response | undefined = undefined;
-	$: {
-		if (response !== undefined && group_selected === undefined) {
-			if (response.type === 'MultipleChoice') {
-				// TODO: handle multiple selections
-				group_selected = choices.findIndex((choice) => {
-					if (response !== undefined && response.type === 'MultipleChoice') {
-						return response.content.selected.includes(choice.uuid);
-					}
-				});
-			}
+	let selected: string[] = loadResponse(response);
+
+	function loadResponse(response: Response | undefined): string[] {
+		if (response !== undefined && response.type === 'MultipleChoice') {
+			return response.content.selected;
 		}
-		if (group_selected !== undefined) {
-			// TODO: handle multiple selections
-			response = { type: 'MultipleChoice', content: { selected: [choices[group_selected].uuid] } };
+		return [];
+	}
+	$: {
+		if (selected.length === 0) {
+			response = { type: 'MultipleChoice', content: { selected } };
 		} else {
 			response = undefined;
 		}
@@ -96,9 +91,11 @@
 		{:else}
 			<ButtonGroup
 				orientation="vertical"
-				buttons={choices.map((choice) => choice.text)}
+				buttons={choices.map((choice) => {
+					return { label: choice.text, value: choice.uuid };
+				})}
 				forceSelection={false}
-				bind:selected={group_selected}
+				bind:selected
 			/>
 			{#each validationErrors.get('response') ?? [] as error}
 				<ValidationErrorRenderer {error} />

--- a/packages/frontend/src/lib/questions/QRating.svelte
+++ b/packages/frontend/src/lib/questions/QRating.svelte
@@ -17,25 +17,25 @@
 	export let maxText = 'high';
 
 	export let response: Response | undefined = undefined;
-	let group_selected: number | undefined = loadResponse(response);
+	let selected: number[] = loadResponse(response);
 
-	function loadResponse(response: Response | undefined): number | undefined {
+	function loadResponse(response: Response | undefined): number[] {
 		if (response !== undefined && response.type === 'Rating') {
-			return response.content.rating - 1;
+			return [response.content.rating - 1];
 		}
-		return undefined;
+		return [];
 	}
 
 	$: {
-		setResponse(group_selected);
+		setResponse(selected);
 	}
 
-	function setResponse(rating: number | undefined) {
-		if (rating === undefined) {
+	function setResponse(rating: number[]) {
+		if (rating.length === 0) {
 			response = undefined;
 			return;
 		}
-		response = { type: 'Rating', content: { rating: rating + 1 } };
+		response = { type: 'Rating', content: { rating: rating[0] + 1 } };
 	}
 
 	export let errors: ValidationError[] = [];
@@ -92,7 +92,7 @@
 				return (i + 1).toString();
 			})}
 			forceSelection={false}
-			bind:selected={group_selected}
+			bind:selected
 		/>
 		<div class="align-rating-text">
 			<span class="description-text">{minText}</span>

--- a/packages/frontend/src/lib/ui/ButtonGroup.svelte
+++ b/packages/frontend/src/lib/ui/ButtonGroup.svelte
@@ -1,31 +1,50 @@
 <script lang="ts">
 	import Button from './Button.svelte';
 
+	interface Item<T> {
+		label: string;
+		value?: T;
+	}
+
 	/**
 	 * Whether the button group should show vertically or horizontally.
 	 */
 	export let orientation: 'horizontal' | 'vertical';
-	export let buttons: string[];
+	export let buttons: Item<unknown>[];
 	export let forceSelection: boolean;
-	export let selected: number | undefined = undefined;
+	let selected: Set<number> = new Set();
 	export let role: string | undefined = undefined;
 	export let size: 'small' | 'normal' | 'large' = 'normal';
+	export let multiple = false;
 
 	function select(i: number) {
-		if(selected == i)
-			if(forceSelection){
+		if (selected.has(i)) {
+			if (forceSelection) {
 				return;
 			}
-			else
-				selected = undefined;
-		else
-			selected = i;
+			selected.delete(i);
+			selected = selected;
+		} else {
+			if (multiple) {
+				selected.add(i);
+				selected = selected;
+			} else {
+				selected = new Set([i]);
+			}
+		}
 	}
 </script>
 
 <div class="button-group {orientation}">
 	{#each buttons as button, i}
-		<Button toggleable={true} size={size} inButtonGroup={true} pressed={selected == i} on:click={() => select(i)} role={role}>{button}</Button>
+		<Button
+			toggleable={true}
+			{size}
+			inButtonGroup={true}
+			pressed={selected.has(i)}
+			on:click={() => select(i)}
+			{role}>{button.label}</Button
+		>
 	{/each}
 </div>
 

--- a/packages/frontend/src/lib/ui/ButtonGroup.svelte
+++ b/packages/frontend/src/lib/ui/ButtonGroup.svelte
@@ -6,16 +6,20 @@
 		value?: T;
 	}
 
+	type T = $$Generic;
+
 	/**
 	 * Whether the button group should show vertically or horizontally.
 	 */
 	export let orientation: 'horizontal' | 'vertical';
-	export let buttons: Item<unknown>[];
+	export let buttons: Item<T>[];
 	export let forceSelection: boolean;
 	let selected: Set<number> = new Set();
 	export let role: string | undefined = undefined;
 	export let size: 'small' | 'normal' | 'large' = 'normal';
 	export let multiple = false;
+	export let selectedIndexes: number[] = [];
+	export let selectedValues: T[] = [];
 
 	function select(i: number) {
 		if (selected.has(i)) {
@@ -32,6 +36,19 @@
 				selected = new Set([i]);
 			}
 		}
+	}
+
+	$: updateSelection(selected);
+
+	function updateSelection(idxs: typeof selected) {
+		selectedIndexes = Array.from(idxs);
+		let values = selectedIndexes.map((i) => buttons[i].value).filter((v) => v !== undefined);
+		if (values.length !== selectedIndexes.length) {
+			selectedValues = [];
+		} else {
+			selectedValues = values as T[];
+		}
+		console.log(selectedIndexes, selectedValues);
 	}
 </script>
 

--- a/packages/frontend/src/routes/demo/+page.svelte
+++ b/packages/frontend/src/routes/demo/+page.svelte
@@ -69,9 +69,9 @@ Buttons
 	<p>Selected: {selected1}</p>
 	<ButtonGroup
 		orientation="horizontal"
-		buttons={[{ label: 'Button 1' }, { label: 'Button 2' }, { label: 'Button 3' }]}
+		buttons={['Button 1', 'Button 2', 'Button 3']}
 		forceSelection={false}
-		bind:selectedIndexes={selected1}
+		bind:selected={selected1}
 	/>
 
 	<h3>Multiple selection, with values</h3>
@@ -85,7 +85,7 @@ Buttons
 		]}
 		forceSelection={false}
 		multiple={true}
-		bind:selectedValues={selected2}
+		bind:selected={selected2}
 	/>
 </div>
 

--- a/packages/frontend/src/routes/demo/+page.svelte
+++ b/packages/frontend/src/routes/demo/+page.svelte
@@ -64,13 +64,22 @@ Buttons
 	<Button toggleable={true}>Toggle Button</Button>
 </div>
 <div>
+	<h3>Single selection</h3>
 	<p>Selected: {group_selected}</p>
 	<ButtonGroup
 		orientation="horizontal"
-		buttons={['Button 1', 'Button 2', 'Button 3', 'Button 4', 'Button 5']}
+		buttons={[{ label: 'Button 1' }, { label: 'Button 2' }, { label: 'Button 3' }]}
 		forceSelection={false}
-		bind:selected={group_selected}
 	/>
+
+	<h3>Multiple selection</h3>
+	<ButtonGroup
+		orientation="horizontal"
+		buttons={[{ label: 'Button 1' }, { label: 'Button 2' }, { label: 'Button 3' }]}
+		forceSelection={false}
+		multiple={true}
+	/>
+	<!-- bind:selected={group_selected} -->
 </div>
 
 Textboxes

--- a/packages/frontend/src/routes/demo/+page.svelte
+++ b/packages/frontend/src/routes/demo/+page.svelte
@@ -40,7 +40,8 @@
 	];
 	let selected_question = 0;
 
-	let group_selected: number | undefined = undefined;
+	let selected1: number[] = [];
+	let selected2: string[] = [];
 </script>
 
 <h1>Component Demo</h1>
@@ -65,21 +66,27 @@ Buttons
 </div>
 <div>
 	<h3>Single selection</h3>
-	<p>Selected: {group_selected}</p>
+	<p>Selected: {selected1}</p>
 	<ButtonGroup
 		orientation="horizontal"
 		buttons={[{ label: 'Button 1' }, { label: 'Button 2' }, { label: 'Button 3' }]}
 		forceSelection={false}
+		bind:selectedIndexes={selected1}
 	/>
 
-	<h3>Multiple selection</h3>
+	<h3>Multiple selection, with values</h3>
+	<p>Selected: {selected2}</p>
 	<ButtonGroup
 		orientation="horizontal"
-		buttons={[{ label: 'Button 1' }, { label: 'Button 2' }, { label: 'Button 3' }]}
+		buttons={[
+			{ label: 'Button 1', value: 'apple' },
+			{ label: 'Button 2', value: 'orange' },
+			{ label: 'Button 3', value: 'banana' }
+		]}
 		forceSelection={false}
 		multiple={true}
+		bind:selectedValues={selected2}
 	/>
-	<!-- bind:selected={group_selected} -->
 </div>
 
 Textboxes


### PR DESCRIPTION
- add `multiple` prop to ButtonGroup, refactor how items are shown a little
- make it so that you can bind to the indexes and values seperately
- get rid of the extra props because they aren't needed
- update impls for QRating and QMultipleChoice
- Qmultiple choice works again

closes #139
closes #127
