### PR TITLE
Added a confirmation window for deleting surveys.

### DIFF
--- a/packages/frontend/src/lib/QuestionsEditor.svelte
+++ b/packages/frontend/src/lib/QuestionsEditor.svelte
@@ -65,7 +65,7 @@
 
 	function removeQuestion(uuid: string) {
 		let confirm = window.confirm('Are you sure you want to delete this question?');
-		if(!confirm) return;
+		if (!confirm) return;
 		questions = questions.filter((q) => q.uuid !== uuid);
 		dispatch('change');
 	}
@@ -94,7 +94,9 @@
 		<option value="MultipleChoice">Multiple Choice</option>
 		<option value="Rating">Rating</option>
 	</select>
-	<Button --margin="5px" size="small" on:click={() => addQuestion(questionToAdd)}>+ Add Question</Button>
+	<Button --margin="5px" size="small" on:click={() => addQuestion(questionToAdd)}>
+		+ Add Question
+	</Button>
 </div>
 
 <style lang="scss">

--- a/packages/frontend/src/lib/QuestionsEditor.svelte
+++ b/packages/frontend/src/lib/QuestionsEditor.svelte
@@ -64,6 +64,8 @@
 	}
 
 	function removeQuestion(uuid: string) {
+		let confirm = window.confirm('Are you sure you want to delete this question?');
+		if(!confirm) return;
 		questions = questions.filter((q) => q.uuid !== uuid);
 		dispatch('change');
 	}

--- a/packages/frontend/src/routes/mysurveys/+page.svelte
+++ b/packages/frontend/src/routes/mysurveys/+page.svelte
@@ -30,7 +30,6 @@
 			console.error(resp.error);
 		}
 	}
-
 </script>
 
 <div class="toolbar">
@@ -53,11 +52,17 @@
 					<td class="published">{survey.published ? 'Yes' : 'No'}</td>
 
 					<td class="share-link">
-						<TextBox value="{window.location.origin}/survey/{survey.id}/respond" disabled copyable />
+						<TextBox
+							value="{window.location.origin}/survey/{survey.id}/respond"
+							disabled
+							copyable
+						/>
 					</td>
 					<td class="actions">
 						<Button --margin="5px" on:click={() => goto(`/survey/${survey.id}/edit`)}>Edit</Button>
-						<Button --margin="5px" kind="danger" on:click={() => doDeleteSurvey(survey.id)}>Delete</Button>
+						<Button --margin="5px" kind="danger" on:click={() => doDeleteSurvey(survey.id)}>
+							Delete
+						</Button>
 					</td>
 				</tr>
 			{/each}

--- a/packages/frontend/src/routes/mysurveys/+page.svelte
+++ b/packages/frontend/src/routes/mysurveys/+page.svelte
@@ -19,6 +19,10 @@
 	}
 
 	async function doDeleteSurvey(survey_id: number) {
+		let confirm = window.confirm('Are you sure you want to delete this survey?');
+		if (!confirm) {
+			return;
+		}
 		let resp = await deleteSurvey(survey_id);
 		if (resp.ok) {
 			surveys = surveys.filter((survey) => survey.id !== survey_id);


### PR DESCRIPTION
This is a quick solution for ensuring people don't accidentally delete surveys. I ran the playwright tests to ensure that this doesn't affect adding/removing surveys and it does not. I do not think a separate test is necessary for this as it is just a OS/browser prompt.

(I don't think any other deletions require confirmation so):

Closes #161 