### PR TITLE
add validation error for QMultipleChoice choice text

### DIFF
--- a/packages/frontend/src/lib/QContainer.svelte
+++ b/packages/frontend/src/lib/QContainer.svelte
@@ -45,7 +45,7 @@
 			{required}
 			bind:response
 			on:change
-			errors={unwrapInnerErrors(errors)}
+			{errors}
 		/>
 	{/if}
 

--- a/packages/frontend/src/lib/questions/QMultipleChoice.svelte
+++ b/packages/frontend/src/lib/questions/QMultipleChoice.svelte
@@ -54,6 +54,7 @@
 
 	export let errors: ValidationError[] = [];
 	$: validationErrors = buildErrorMapFromFields(errors);
+	$: console.log(errors);
 </script>
 
 <Container>
@@ -107,11 +108,12 @@
 					<Button kind="danger" size="small" on:click={() => removeChoice(i)}>x</Button>
 				</div>
 			{/each}
+			<div>
+				{#each validationErrors.get('text') ?? [] as error}
+					<ValidationErrorRenderer {error} />
+				{/each}
+			</div>
 			<Button on:click={addChoice}>+</Button>
-			<!-- TODO: show errors under the choices that have them -->
-			{#each validationErrors.get('choices') ?? [] as error}
-				<ValidationErrorRenderer {error} />
-			{/each}
 		{:else}
 			<ButtonGroup
 				orientation="vertical"

--- a/packages/frontend/src/lib/questions/QMultipleChoice.svelte
+++ b/packages/frontend/src/lib/questions/QMultipleChoice.svelte
@@ -9,7 +9,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import './questions.scss';
 	import ValidationErrorRenderer from '$lib/ValidationErrorRenderer.svelte';
-	import { buildErrorMapFromFields } from '$lib/validation';
+	import { buildErrorMapFromFields, buildErrorMapFromUuids } from '$lib/validation';
 
 	export let editmode = false;
 	export let prompt: string;
@@ -54,6 +54,7 @@
 
 	export let errors: ValidationError[] = [];
 	$: validationErrors = buildErrorMapFromFields(errors);
+	$: choiceErrors = buildErrorMapFromUuids(validationErrors.get('choices') ?? []);
 </script>
 
 <Container>
@@ -106,10 +107,15 @@
 					<TextBox bind:value={choice.text} placeholder="Enter text..." on:change />
 					<Button kind="danger" size="small" on:click={() => removeChoice(i)}>x</Button>
 				</div>
+				{#each choiceErrors.get(choice.uuid) ?? [] as error}
+					<ValidationErrorRenderer {error} />
+				{/each}
 			{/each}
 			<div>
-				{#each validationErrors.get('text') ?? [] as error}
-					<ValidationErrorRenderer {error} />
+				{#each validationErrors.get('choices') ?? [] as error}
+					{#if error.type !== 'Inner'}
+						<ValidationErrorRenderer {error} />
+					{/if}
 				{/each}
 			</div>
 			<Button on:click={addChoice}>+</Button>

--- a/packages/frontend/src/lib/questions/QMultipleChoice.svelte
+++ b/packages/frontend/src/lib/questions/QMultipleChoice.svelte
@@ -54,7 +54,6 @@
 
 	export let errors: ValidationError[] = [];
 	$: validationErrors = buildErrorMapFromFields(errors);
-	$: console.log(errors);
 </script>
 
 <Container>


### PR DESCRIPTION
- Validation error now displayed beneath the multiple choice options if error is encountered during edit mode
- Currently, it refers to the multiple choice text boxes as "text" due to the name of the data field. ex: "text is required"

Closes #165 